### PR TITLE
Doc: update issue templates' default labels

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,5 +1,5 @@
 title: "[Ideas] "
-labels: ["enhancement"]
+labels: ["type: Enhancement"]
 body:
   - type: markdown
     attributes:

--- a/.github/DISCUSSION_TEMPLATE/proposal.yml
+++ b/.github/DISCUSSION_TEMPLATE/proposal.yml
@@ -1,4 +1,5 @@
 title: "[Proposal] "
+labels: ["type: Proposal"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,7 @@
 name: "\U0001F41B Bug Report"
 description: Problems and issues with code in Cloudberry Database core.
 title: "[Bug] "
-labels: ["bug"]
+labels: ["type: Bug"]
 body:
   - type: markdown
     attributes:

--- a/.gitmessage
+++ b/.gitmessage
@@ -41,3 +41,7 @@ Add your commit body here
 # Note: Usage - use this config for your own git
 # Run the configure cmd in the terminal
 # `git config --global commit.template .gitmessage`
+#
+#
+#
+#


### PR DESCRIPTION
Update GitHub issue templates' default labels by our latest labels configuration.

<!--
Thank you for contributing! 
***If you're the first time contributor, please sign the Contributor License Agreement(CLA).***
-->

<!--In case of an existing issue or discussions, please reference it-->
<!--Remove this section if no corresponding issue.-->

---

### Change logs

Update GitHub Issue and Discussion template default labels settings, according to our latest labels system.

### Why are the changes needed?

Unify the labels setting.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

No core change for CBDB. No test is needed.

### Contributor's Checklist
Here are some reminders before you submit the pull request:
* Document changes
* Communicate in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (list them if needed)
* Add tests for the change
* Pass `make installcheck`
* Pass `make -C src/test installcheck-cbdb-parallel`

<!--Who can review & approve your PR?
Feel free to @dev team for the approve! -->
