### PR TITLE
Enable Parallel-oblivious Hash Left Anti Semi (Not-In) Join

### DIFF
--- a/src/backend/optimizer/path/joinpath.c
+++ b/src/backend/optimizer/path/joinpath.c
@@ -2299,7 +2299,6 @@ hash_inner_and_outer(PlannerInfo *root,
 			save_jointype != JOIN_UNIQUE_OUTER &&
 			save_jointype != JOIN_FULL &&
 			save_jointype != JOIN_RIGHT &&
-			save_jointype != JOIN_LASJ_NOTIN &&
 			save_jointype != JOIN_DEDUP_SEMI &&
 			save_jointype != JOIN_DEDUP_SEMI_REVERSE &&
 			outerrel->partial_pathlist != NIL &&
@@ -2319,6 +2318,7 @@ hash_inner_and_outer(PlannerInfo *root,
 			 */
 			if (innerrel->partial_pathlist != NIL &&
 				save_jointype != JOIN_UNIQUE_INNER &&
+				save_jointype != JOIN_LASJ_NOTIN &&
 				enable_parallel_hash)
 			{
 				cheapest_partial_inner =

--- a/src/test/regress/expected/gp_parallel.out
+++ b/src/test/regress/expected/gp_parallel.out
@@ -1590,6 +1590,81 @@ select * from t1 order by c2 asc limit 3 offset 5;
 
 abort;
 --
+-- Test Parallel Hash Left Anti Semi (Not-In) Join(parallel-oblivious).
+--
+create table t1(c1 int, c2 int) using ao_row distributed by (c1);
+create table t2(c1 int, c2 int) using ao_row distributed by (c1);
+create table t3_null(c1 int, c2 int) using ao_row distributed by (c1);
+set enable_parallel = on;
+set gp_appendonly_insert_files = 2;
+set gp_appendonly_insert_files_tuples_range = 100;
+set max_parallel_workers_per_gather = 2;
+insert into t1 select i, i from generate_series(1, 5000000) i;
+insert into t2 select i+1, i from generate_series(1, 1200) i;
+insert into t3_null select i+1, i from generate_series(1, 1200) i;
+insert into t3_null values(NULL, NULL);
+analyze t1;
+analyze t2;
+analyze t3_null;
+explain(costs off) select sum(t1.c1) from t1 where c1 not in (select c1 from t2);
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 6:1  (slice1; segments: 6)
+         ->  Partial Aggregate
+               ->  Hash Left Anti Semi (Not-In) Join
+                     Hash Cond: (t1.c1 = t2.c1)
+                     ->  Parallel Seq Scan on t1
+                     ->  Hash
+                           ->  Broadcast Motion 3:6  (slice2; segments: 3)
+                                 ->  Seq Scan on t2
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select sum(t1.c1) from t1 where c1 not in (select c1 from t2);
+      sum       
+----------------
+ 12500001778200
+(1 row)
+
+explain(costs off) select * from t1 where c1 not in (select c1 from t3_null);
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Gather Motion 6:1  (slice1; segments: 6)
+   ->  Hash Left Anti Semi (Not-In) Join
+         Hash Cond: (t1.c1 = t3_null.c1)
+         ->  Parallel Seq Scan on t1
+         ->  Hash
+               ->  Broadcast Motion 3:6  (slice2; segments: 3)
+                     ->  Seq Scan on t3_null
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select * from t1 where c1 not in (select c1 from t3_null);
+ c1 | c2 
+----+----
+(0 rows)
+
+-- non-parallel results.
+set enable_parallel = off;
+select sum(t1.c1) from t1 where c1 not in (select c1 from t2);
+      sum       
+----------------
+ 12500001778200
+(1 row)
+
+select * from t1 where c1 not in (select c1 from t3_null);
+ c1 | c2 
+----+----
+(0 rows)
+
+drop table t1;
+drop table t2;
+drop table t3_null;
+--
+-- End of Test Parallel Hash Left Anti Semi (Not-In) Join.
+--
+--
 -- Test alter ao/aocs table parallel_workers options
 --
 begin;


### PR DESCRIPTION
We have Parallel Nested Loop Left Anti Semi (Not-In) Join, but in CBDB, enable_nestloop is default false.
And we disable Parallel Hash Left Anti Semi (Not-In) Join before, because we thought that it will return wrong results and it's hard to tell null values in which batch.
So that in CBDB now, there is usually a non-parallel Hash LASJ and it shows degradation performance at a internal test(by @HuSen8891 ) TPCH 's SQL16 case.

After consideration, I think it's only problem for Parallel-aware Hash Left Anti Semi (Not-In) Join with a shared Hash table(yeah, working on another branch to enable that), for no shared Hash table(Parallel-oblivious), it would have all the data it should have from inner side. And it doesn't matter null values in which batch.

Enable Parallel-oblivious Hash Left Anti Semi (Not-In) Join will benefit a lot if outer table is huge and inner table is very small(perfect for TPCH SQL16  see #31 ).

Performance:(Qingyun Cloud, avg for 3 times, t1 has 100 million rows join t2 with 1200 rows, see [0] for DDL and DML, non-parallel compared with parallel_workers 2, 4, 6 , 8) of 

```sql
            select sum(t1.c1) from t1 where c1 not in (select c1 from t2);
```

![PH-LASJ](https://github.com/cloudberrydb/cloudberrydb/assets/17311022/c06d516f-765d-4186-ac30-42a53eff3a6d)

|parallel workers|avg duration(s)| 1st | 2nd | 3rd
-- | -- | -- | -- | --
0 | 18.88366667 | 18.286 | 19.305 | 19.06
2 | 9.719333333 | 9.791 | 9.689 | 9.678
4 | 7.438333333 | 7.541 | 7.15 | 7.624
6 | 7.101333333 | 7.019 | 7.236 | 7.049
8 | 6.491333333 | 6.218 | 6.206 | 7.05

</byte-sheet-html-origin>

Typical LASJ plans are as below, see [1] below for example DDL and DML.

**Non-parallel** plan:
```sql
explain(analyze, costs off) select sum(t1.c1) from t1 where c1 not in (select c1 from t2);
                                                       QUERY PLAN
------------------------------------------------------------------------------------------------------------------------
 Finalize Aggregate (actual time=1808.872..1808.875 rows=1 loops=1)
   ->  Gather Motion 3:1  (slice1; segments: 3) (actual time=1745.235..1808.858 rows=3 loops=1)
         ->  Partial Aggregate (actual time=1808.622..1808.625 rows=1 loops=1)
               ->  Hash Left Anti Semi (Not-In) Join (actual time=2.890..1583.005 rows=1667434 loops=1)
                     Hash Cond: (t1.c1 = t2.c1)
                     Extra Text: (seg2)   Hash chain length 1.0 avg, 2 max, using 1199 of 524288 buckets.
                     ->  Seq Scan on t1 (actual time=0.355..678.531 rows=1667832 loops=1)
                     ->  Hash (actual time=2.068..2.069 rows=1200 loops=1)
                           Buckets: 524288  Batches: 1  Memory Usage: 4139kB
                           ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual time=1.476..1.772 rows=1200 loops=1)
                                 ->  Seq Scan on t2 (actual time=0.356..0.499 rows=407 loops=1)
 Planning Time: 0.454 ms
   (slice0)    Executor memory: 124K bytes.
   (slice1)    Executor memory: 4443K bytes avg x 3x(0) workers, 4443K bytes max (seg0).  Work_mem: 4139K bytes max.
   (slice2)    Executor memory: 262K bytes avg x 3x(0) workers, 262K bytes max (seg0).
 Memory used:  128000kB
 Optimizer: Postgres query optimizer
 Execution Time: 1809.517 ms
(18 rows)
Time: 1810.827 ms (00:01.811)
```

**Parallel** plan:
```sql
explain(analyze, costs off) select sum(t1.c1) from t1 where c1 not in (select c1 from t2);
                                                       QUERY PLAN
------------------------------------------------------------------------------------------------------------------------
 Finalize Aggregate (actual time=758.707..758.710 rows=1 loops=1)
   ->  Gather Motion 6:1  (slice1; segments: 6) (actual time=668.747..758.685 rows=6 loops=1)
         ->  Partial Aggregate (actual time=752.479..752.483 rows=1 loops=1)
               ->  Hash Left Anti Semi (Not-In) Join (actual time=3.010..565.127 rows=833732 loops=1)
                     Hash Cond: (t1.c1 = t2.c1)
                     Extra Text: (seg2)   Hash chain length 1.0 avg, 2 max, using 1199 of 524288 buckets.
                     ->  Parallel Seq Scan on t1 (actual time=0.368..231.049 rows=833932 loops=1)
                     ->  Hash (actual time=2.148..2.149 rows=1200 loops=1)
                           Buckets: 524288  Batches: 1  Memory Usage: 4139kB
                           ->  Broadcast Motion 3:6  (slice2; segments: 3) (actual time=0.203..1.779 rows=1200 loops=1)
                                 ->  Seq Scan on t2 (actual time=0.361..0.499 rows=407 loops=1)
 Planning Time: 0.470 ms
   (slice0)    Executor memory: 124K bytes.
   (slice1)    Executor memory: 4483K bytes avg x 6x(0) workers, 4483K bytes max (seg0).  Work_mem: 4139K bytes max.
   (slice2)    Executor memory: 262K bytes avg x 3x(0) workers, 262K bytes max (seg0).
 Memory used:  128000kB
 Optimizer: Postgres query optimizer
 Execution Time: 759.440 ms
(18 rows)
Time: 760.874 ms
```

[0] Example:
```sql
create table t1(c1 int, c2 int) using ao_row with(parallel_workers=8) distributed by (c1);
create table t2(c1 int, c2 int) using ao_row with(parallel_workers=8) distributed by (c1);
set enable_parallel = on;
set gp_appendonly_insert_files = 8;
set gp_appendonly_insert_files_tuples_range = 100;
set max_parallel_workers_per_gather = 8;
insert into t1 select i, i from generate_series(1, 100000000) i;
insert into t2 select i+1, i from generate_series(1, 1200) i;
analyze t1;
analyze t2;
explain(costs off) select sum(t1.c1) from t1 where c1 not in (select c1 from t2);
select sum(t1.c1) from t1 where c1 not in (select c1 from t2);
```


[1] Example:
```sql
create table t1(c1 int, c2 int) using ao_row distributed by (c1); create table t2(c1 int, c2 int) using ao_row distributed by (c1); set enable_parallel = on;
set gp_appendonly_insert_files = 2;
set gp_appendonly_insert_files_tuples_range = 100; 
set max_parallel_workers_per_gather = 2;
insert into t1 select i, i from generate_series(1, 5000000) i;
insert into t2 select i+1, i from generate_series(1, 1200) i; 
analyze t1;
analyze t2;
explain(costs off) select sum(t1.c1) from t1 where c1 not in (select c1 from t2);
```

Authored-by: Zhang Mingli avamingli@gmail.com

<!--
Thank you for contributing! 
***If you're the first time contributor, please sign the Contributor License Agreement(CLA).***
-->

<!--In case of an existing issue or discussions, please reference it-->
closes: #ISSUE
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist
Here are some reminders before you submit the pull request:
* Document changes
* Communicate in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (list them if needed)
* Add tests for the change
* Pass `make installcheck`
* Pass `make -C src/test installcheck-cbdb-parallel`

<!--Who can review & approve your PR?
Feel free to @dev team for the approve! -->
