### PR TITLE
Add Parallel Bitmap Heap Scan case

### DIFF
--- a/src/test/regress/expected/gp_parallel.out
+++ b/src/test/regress/expected/gp_parallel.out
@@ -206,6 +206,77 @@ commit;
 drop table ao1;
 drop table ao2;
 drop table aocs1;
+-- test Parallel Bitmap Heap Scan
+begin;
+create table t1(c1 int, c2 int) with(parallel_workers=2) distributed by (c1);
+set local enable_parallel = on;
+create index on t1(c2);
+insert into t1 select i, i from generate_series(1, 10000000) i;
+analyze t1;
+set local force_parallel_mode = 1;
+set local enable_seqscan = off;
+explain(locus, costs off) select c2 from t1;
+                 QUERY PLAN                 
+--------------------------------------------
+ Gather Motion 6:1  (slice1; segments: 6)
+   Locus: Entry
+   ->  Parallel Bitmap Heap Scan on t1
+         Locus: HashedWorkers
+         Parallel Workers: 2
+         ->  Bitmap Index Scan on t1_c2_idx
+               Locus: NULL
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+-- results check
+explain(locus, costs off) select count(c2) from t1;
+                       QUERY PLAN                       
+--------------------------------------------------------
+ Finalize Aggregate
+   Locus: Entry
+   ->  Gather Motion 6:1  (slice1; segments: 6)
+         Locus: Entry
+         ->  Partial Aggregate
+               Locus: HashedWorkers
+               Parallel Workers: 2
+               ->  Parallel Bitmap Heap Scan on t1
+                     Locus: HashedWorkers
+                     Parallel Workers: 2
+                     ->  Bitmap Index Scan on t1_c2_idx
+                           Locus: NULL
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+select count(c2) from t1;
+  count   
+----------
+ 10000000
+(1 row)
+
+set local enable_parallel = off;
+explain(locus, costs off) select count(c2) from t1;
+                       QUERY PLAN                       
+--------------------------------------------------------
+ Finalize Aggregate
+   Locus: Entry
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Locus: Entry
+         ->  Partial Aggregate
+               Locus: Hashed
+               ->  Bitmap Heap Scan on t1
+                     Locus: Hashed
+                     ->  Bitmap Index Scan on t1_c2_idx
+                           Locus: NULL
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select count(c2) from t1;
+  count   
+----------
+ 10000000
+(1 row)
+
+abort;
 -- test gp_appendonly_insert_files doesn't take effect
 begin;
 create table t (x int);


### PR DESCRIPTION
Issue https://github.com/cloudberrydb/cloudberrydb/issues/65 says we need to support Parallel Bitmap Heap Scan.
I don't have the impression that we disable it at some time.
Have a check and yeah, we have it, but lack of a case.
Add a case to show that.

```sql
explain(costs off) select c2 from t1;
                 QUERY PLAN
--------------------------------------------
 Gather Motion 6:1  (slice1; segments: 6)
   ->  Parallel Bitmap Heap Scan on t1
         ->  Bitmap Index Scan on t1_c2_idx
```

By adding the cases, found that the underling  Bitmap Index Scan  Locus is NULL.
It's not so right and may cause confusion even it doesn't have an impact on Plan Execution.

```sql
explain(locus, costs off) select c2 from t1;
                 QUERY PLAN                 
--------------------------------------------
 Gather Motion 6:1  (slice1; segments: 6)
   Locus: Entry
   ->  Parallel Bitmap Heap Scan on t1
         Locus: HashedWorkers
         Parallel Workers: 2
         ->  Bitmap Index Scan on t1_c2_idx
               Locus: NULL.    <-------------------
 Optimizer: Postgres query optimizer
(8 rows)
```
I have new an issue #86 to track that.


Authored-by: Zhang Mingli avamingli@gmail.com

<!--
Thank you for contributing! 
***If you're the first time contributor, please sign the Contributor License Agreement(CLA).***
-->

<!--In case of an existing issue or discussions, please reference it-->
closes: #65 
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist
Here are some reminders before you submit the pull request:
* Document changes
* Communicate in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (list them if needed)
* Add tests for the change
* Pass `make installcheck`
* Pass `make -C src/test installcheck-cbdb-parallel`

<!--Who can review & approve your PR?
Feel free to @dev team for the approve! -->
