### PR TITLE
Fix interconnection udpifc UAF in ipc teardown

### DIFF
--- a/contrib/interconnect/ic_internal.h
+++ b/contrib/interconnect/ic_internal.h
@@ -165,7 +165,15 @@ typedef struct ChunkTransportStateEntry
 	int			motNodeId;
 	bool		valid;
 
-	/* Connection array */
+	/* Connection array
+	 *
+	 * MUST pay attention: use getMotionConn to get MotionConn.
+	 * must not use `->conns[index]` to get MotionConn. Because the struct
+	 * MotionConn is a base structure for MotionConnTCP and
+	 * MotionConnUDP. After connection setup, the `conns` will be fill
+	 * with MotionConnUDP/MotionConnTCP, but the pointer still is
+	 * MotionConn which should use `CONTAINER_OF` to get the real object.
+	 */
 	MotionConn *conns;
 	int			numConns;
 

--- a/contrib/interconnect/udp/ic_udpifc.c
+++ b/contrib/interconnect/udp/ic_udpifc.c
@@ -3413,10 +3413,13 @@ static bool
 chunkTransportStateEntryInitialized(ChunkTransportState *transportStates,
 									int16 motNodeID)
 {
-	if (motNodeID > transportStates->size || !transportStates->states[motNodeID - 1].valid)
+	ChunkTransportStateEntry *pEntry = NULL;
+	if (motNodeID > transportStates->size) {
 		return false;
+	}
 
-	return true;
+	getChunkTransportStateNoValid(transportStates, motNodeID, &pEntry);
+	return pEntry->valid;
 }
 
 /*

--- a/src/include/cdb/cdbinterconnect.h
+++ b/src/include/cdb/cdbinterconnect.h
@@ -192,7 +192,16 @@ typedef struct MotionConnSentRecordTypmodEnt
 
 typedef struct ChunkTransportState
 {
-	/* array of per-motion-node chunk transport state */
+	/* array of per-motion-node chunk transport state
+	 *
+	 * MUST pay attention: use getChunkTransportStateNoValid/getChunkTransportState
+	 * to get ChunkTransportStateEntry.
+	 * must not use `->states[index]` to get ChunkTransportStateEntry. Because the struct
+	 * ChunkTransportStateEntry is a base structure for ChunkTransportStateEntryTCP and
+	 * ChunkTransportStateEntryUDP. After interconnect setup, the `states` will be fill
+	 * with EntryUDP/EntryTCP, but the pointer still is ChunkTransportStateEntry which
+	 * should use `CONTAINER_OF` to get the real object.
+	 */
 	int size;
 	struct ChunkTransportStateEntry *states;
 


### PR DESCRIPTION
**Cherry-pick from Gitlab master branch to fix udpifc crash.**

Problem details:

In function chunkTransportStateEntryInitialized got **wrong** valid with motNodeID When tear down happen in udpifc, the outgoing route may not delete entry in shared htab. The htab will be shared with rxthread.

After main thread tear down, some of conns will be freed by MemoryContextReset But in the same time, htab will hold the invalid conn ptr in rxthread Then got core dump.

Fixed:

Changed the chunkTransportStateEntryInitialized, using the getChunkTransportState* to get the right entry Also do not direct access states in ChunkTransportState.

<!--
Thank you for contributing! 
***If you're the first time contributor, please sign the Contributor License Agreement(CLA).***
-->

<!--In case of an existing issue or discussions, please reference it-->
closes: #ISSUE
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist
Here are some reminders before you submit the pull request:
* Document changes
* Communicate in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (list them if needed)
* Add tests for the change
* Pass `make installcheck`
* Pass `make -C src/test installcheck-cbdb-parallel`

<!--Who can review & approve your PR?
Feel free to @dev team for the approve! -->
