### PR TITLE
fix create extensions changes user search_path (fix #59)

### DIFF
--- a/gpcontrib/gp_debug_numsegments/gp_debug_numsegments--1.0.sql
+++ b/gpcontrib/gp_debug_numsegments/gp_debug_numsegments--1.0.sql
@@ -3,8 +3,6 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION gp_debug_numsegments" to load this file. \quit
 
-SET search_path = public;
-
 -- This function set the default numsegments when creating tables.
 -- This form accepts a text argument: 'full', 'minimal', 'random'.
 CREATE OR REPLACE FUNCTION gp_debug_set_create_table_default_numsegments(text) RETURNS text

--- a/gpcontrib/gp_debug_numsegments/gp_debug_numsegments.control
+++ b/gpcontrib/gp_debug_numsegments/gp_debug_numsegments.control
@@ -2,4 +2,4 @@
 comment = 'get / set default numsegments when creating tables'
 default_version = '1.0'
 module_pathname = '$libdir/gp_debug_numsegments'
-relocatable = true
+schema = public

--- a/gpcontrib/gp_distribution_policy/gp_distribution_policy--1.0.sql
+++ b/gpcontrib/gp_distribution_policy/gp_distribution_policy--1.0.sql
@@ -3,8 +3,6 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION gp_distribution_policy" to load this file. \quit
 
-SET search_path = public;
-
 -- This function validates the data distribution in a table in a segment.
 CREATE OR REPLACE FUNCTION gp_distribution_policy_table_check(relid regclass)
 RETURNS boolean

--- a/gpcontrib/gp_distribution_policy/gp_distribution_policy.control
+++ b/gpcontrib/gp_distribution_policy/gp_distribution_policy.control
@@ -2,4 +2,4 @@
 comment = 'check distribution policy in a GPDB cluster'
 default_version = '1.0'
 module_pathname = '$libdir/gp_distribution_policy'
-relocatable = true
+schema = public

--- a/gpcontrib/gp_internal_tools/gp_internal_tools--1.0.0.sql
+++ b/gpcontrib/gp_internal_tools/gp_internal_tools--1.0.0.sql
@@ -5,11 +5,6 @@
 --------------------------------------------------------------------------------
 --  Session state functions and views                                         --
 --------------------------------------------------------------------------------
---  Adjust this setting to control where the objects get created.
-
-CREATE SCHEMA session_state;
-SET search_path = session_state;
-
 -- SessionState views
 --------------------------------------------------------------------------------
 
@@ -105,5 +100,3 @@ pg_stat_activity as S
 ON M.sessionid = S.sess_id;
 
 GRANT SELECT ON session_level_memory_consumption TO public;
-
-SET search_path TO DEFAULT;

--- a/gpcontrib/gp_internal_tools/gp_internal_tools.control
+++ b/gpcontrib/gp_internal_tools/gp_internal_tools.control
@@ -1,3 +1,3 @@
 comment = 'Different internal tools for Cloudberry Database'
 default_version = '1.0.0'
-relocatable = true
+schema = session_state

--- a/gpcontrib/gp_sparse_vector/gp_sparse_vector--1.0.1.sql
+++ b/gpcontrib/gp_sparse_vector/gp_sparse_vector--1.0.1.sql
@@ -1,10 +1,6 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION gp_sparse_vector" to load this file. \quit
 
-CREATE SCHEMA sparse_vector;
-
-SET search_path TO sparse_vector;
-
 DROP TYPE IF EXISTS svec CASCADE;
 CREATE TYPE svec;
 
@@ -373,5 +369,3 @@ OPERATOR        3       == ,
 OPERATOR        4       >= ,
 OPERATOR        5       > ,
 FUNCTION        1       svec_l2_cmp(svec, svec);
-
-SET search_path TO DEFAULT;

--- a/gpcontrib/gp_sparse_vector/gp_sparse_vector.control
+++ b/gpcontrib/gp_sparse_vector/gp_sparse_vector.control
@@ -1,3 +1,3 @@
 comment = 'SParse vector implementation for GreenPlum'
 default_version = '1.0.1'
-relocatable = true
+schema = sparse_vector


### PR DESCRIPTION
<!--Thank you for contributing!-->

<!--In case of an existing issue or discussions, please reference it-->
closes: #59
<!--Remove this section if no corresponding issue.-->

---

### Change logs

Four GP extensions (i.e., `gp_sparse_vector`, `gp_distribution_policy`, `gp_debug_numsegments` and `gp_internal_tools`) change user `search_path` w/o restoring them. This PR fix this problem by using PL/pgSQL to remember the user search_path and restoring it afterwards. This is a very common idioms in PG extensions (e.g., hstore, intagg) so this should be no problem.

### Why are the changes needed?

PostgreSQL / Greenplum extensions shouldn't change user's `search_path`.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

A Python script in https://github.com/cloudberrydb/cloudberrydb/issues/59#issuecomment-1655240732 has been executed to make sure that all extensions in `pg_available_extensions` are now preserve user's `search_path`:

```
/home/gpadmin/.virtualenvs/Test59/bin/python /home/gpadmin/PyCharmProjects/Test59/main.py 
amcheck Pass
autoinc Pass
bloom Pass
btree_gin Pass
btree_gist Pass
citext Pass
dblink Pass
dict_int Pass
dict_xsyn Pass
file_fdw Pass
fuzzystrmatch Pass
gp_debug_numsegments Pass
gp_distribution_policy Pass
gp_exttable_fdw Duplicated
gp_inject_fault Pass
gp_internal_tools Pass
gp_legacy_string_agg Pass
gp_replica_check Pass
gp_sparse_vector Pass
hstore Pass
hstore_plpython2u Error could not open extension control file "/home/gpadmin/install/cbdb/share/postgresql/extension/plpython2u.control": No such file or directory
hstore_plpython3u Pass
hstore_plpythonu Error could not open extension control file "/home/gpadmin/install/cbdb/share/postgresql/extension/plpythonu.control": No such file or directory
insert_username Pass
intagg Pass
intarray Pass
isn Pass
jsonb_plpython2u Error could not open extension control file "/home/gpadmin/install/cbdb/share/postgresql/extension/plpython2u.control": No such file or directory
jsonb_plpython3u Pass
jsonb_plpythonu Error could not open extension control file "/home/gpadmin/install/cbdb/share/postgresql/extension/plpythonu.control": No such file or directory
ltree Pass
ltree_plpython2u Error could not open extension control file "/home/gpadmin/install/cbdb/share/postgresql/extension/plpython2u.control": No such file or directory
ltree_plpython3u Pass
ltree_plpythonu Error could not open extension control file "/home/gpadmin/install/cbdb/share/postgresql/extension/plpythonu.control": No such file or directory
moddatetime Pass
old_snapshot Pass
pageinspect Pass
pg_buffercache Pass
pg_freespacemap Pass
pg_prewarm Pass
pg_stat_statements Pass
pg_surgery Pass
pg_trgm Pass
pg_visibility Pass
pgcrypto Pass
pgrowlocks Pass
pgstattuple Pass
plperl Pass
plperlu Pass
plpgsql Duplicated
plpython3u Duplicated
pxf_fdw Pass
refint Pass
seg Error permission denied: "pg_depend" is a system catalog
tablefunc Pass
tcn Pass
tsm_system_rows Pass
tsm_system_time Pass
unaccent Pass

Process finished with exit code 0
```
(only `FAILED` indicates that an extension's failed at preserving user's `search_path`)