### PR TITLE
Fix regress test line no failures

### DIFF
--- a/contrib/extprotocol/expected/exttableext.out
+++ b/contrib/extprotocol/expected/exttableext.out
@@ -1627,7 +1627,7 @@ ERROR:  protocol "demoprot" does not exist  (seg0 slice1 rh55-qavm55:7532 pid=18
     -- However demoprot implementation prevents using any other protocol name than "demoprot"
     -- therefore the error is expected.
     select count(*) from exttabtest_r_new;
-ERROR:  internal error: demoprot called with a different protocol (demoprot_new) (gpextprotocol.c:107)  (seg0 slice1 rh55-qavm55:7532 pid=18394) (cdbdisp.c:1453)
+ERROR:  internal error: demoprot called with a different protocol (demoprot_new) (seg0 slice1 rh55-qavm55:7532 pid=18394) (cdbdisp.c:1453)
 CONTEXT:  External table exttabtest_r_new, line 1 of file demoprot_new://exttabtest.txt
     -- Rename protocol name back to demoprot
     ALTER PROTOCOL demoprot_new RENAME to demoprot;

--- a/contrib/extprotocol/gpextprotocol.c
+++ b/contrib/extprotocol/gpextprotocol.c
@@ -104,8 +104,10 @@ demoprot_import(PG_FUNCTION_ARGS)
 		myData->filename = pstrdup(parsed_url->path);
 	
 		if(strcasecmp(parsed_url->protocol, p_name) != 0)
-			elog(ERROR, "internal error: demoprot called with a different protocol (%s)",
-						parsed_url->protocol);
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						errmsg("internal error: demoprot called with a different protocol (%s)",
+						parsed_url->protocol)));
 
 		/* An example of checking options */
 		check_ext_options(fcinfo);

--- a/src/backend/task/job_metadata.c
+++ b/src/backend/task/job_metadata.c
@@ -207,8 +207,9 @@ ScheduleCronJob(text *scheduleText, text *commandText, text *databaseText,
 	aclresult = pg_database_aclcheck(get_database_oid(database_name, false),
 									 userIdcheckacl, ACL_CONNECT);
 	if (aclresult != ACLCHECK_OK)
-		elog(ERROR, "User %s does not have CONNECT privilege on %s",
-			 GetUserNameFromId(userIdcheckacl, false), database_name);
+		ereport(ERROR, (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+						errmsg("User %s does not have CONNECT privilege on %s",
+								GetUserNameFromId(userIdcheckacl, false), database_name)));
 
 	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
 
@@ -680,7 +681,9 @@ AlterCronJob(int64 jobId, char *schedule, char *command,
 										 userIdcheckacl, ACL_CONNECT);
 
 		if (aclresult != ACLCHECK_OK)
-			elog(ERROR, "User %s does not have CONNECT privilege on %s", GetUserNameFromId(userIdcheckacl, false), database_name);
+			ereport(ERROR, (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+							errmsg("User %s does not have CONNECT privilege on %s",
+									GetUserNameFromId(userIdcheckacl, false), database_name)));
 	}
 
 	/* ensure schedule is valid */

--- a/src/test/regress/expected/task.out
+++ b/src/test/regress/expected/task.out
@@ -61,10 +61,10 @@ create user task_cron with password 'pwd';
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 -- Create a task for another user
 create task another_user_task schedule '* 10 * * *'  database task_dbno user task_cron as 'vacuum';
-ERROR:  User task_cron does not have CONNECT privilege on task_dbno (job_metadata.c:210)
+ERROR:  User task_cron does not have CONNECT privilege on task_dbno
 -- Schedule a task for this user on the database that does not accept connections
 alter task vacuum_db database task_dbno user task_cron;
-ERROR:  User task_cron does not have CONNECT privilege on task_dbno (job_metadata.c:683)
+ERROR:  User task_cron does not have CONNECT privilege on task_dbno
 -- Schedule a task that user doest not exist
 alter task vacuum_db user hopedoesnotexist;
 ERROR:  role "hopedoesnotexist" does not exist


### PR DESCRIPTION

### Change logs

These two tests(exttableext and task) will print the line no of functions in regress test. But it may get different results in different OS, like Ubuntu and Kylin.

So just remove the line-no output in tests. It has no effect on the correctness of the results.

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [x] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [x] Sign the Contributor License Agreement as prompted for your first-time contribution.
- [x] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [x] Document changes.
- [x] Add tests for the change
- [x] Pass `make installcheck`
- [x] Pass `make -C src/test installcheck-cbdb-parallel`
- [x] Feel free to @cloudberrydb/dev team for review and approval when your PR is ready🥳
