### PR TITLE
FIX: constraint check exception with snapshot memory leak in AO/AOCS

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1564,8 +1564,8 @@ aocs_fetch_init(Relation relation,
 						   visimaprelid,
 						   visimapidxid,
 						   AccessShareLock,
-						   appendOnlyMetaDataSnapshot);
-
+						   InvalidSnapshot);
+	
 	return aocsFetchDesc;
 }
 

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -705,6 +705,7 @@ aoco_index_fetch_tuple(struct IndexFetchTableData *scan,
                              bool *call_again, bool *all_dead)
 {
 	IndexFetchAOCOData *aocoscan = (IndexFetchAOCOData *) scan;
+	bool				found = false;
 
 	if (!aocoscan->aocofetch)
 	{
@@ -740,15 +741,19 @@ aoco_index_fetch_tuple(struct IndexFetchTableData *scan,
 	 */
 	Assert(aocoscan->aocofetch->snapshot == snapshot);
 
+	aocoscan->aocofetch->visibilityMap.visimapStore.snapshot = snapshot;
+
 	ExecClearTuple(slot);
 
 	if (aocs_fetch(aocoscan->aocofetch, (AOTupleId *) tid, slot))
 	{
 		ExecStoreVirtualTuple(slot);
-		return true;
+		found = true;
 	}
 
-	return false;
+	aocoscan->aocofetch->visibilityMap.visimapStore.snapshot = InvalidSnapshot;
+
+	return found;
 }
 
 static void

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -1813,6 +1813,8 @@ aoco_scan_bitmap_next_tuple(TableScanDesc scan,
 		aocsBitmapScan->bitmapScanDesc[aocsBitmapScan->whichDesc].bitmapFetch = aocoFetchDesc;
 	}
 
+	aocoFetchDesc->visibilityMap.visimapStore.snapshot = aocsBitmapScan->appendOnlyMetaDataSnapshot;
+
 	ExecClearTuple(slot);
 
 	/* ntuples == -1 indicates a lossy page */
@@ -1847,11 +1849,12 @@ aoco_scan_bitmap_next_tuple(TableScanDesc scan,
 			/* OK to return this tuple */
 			ExecStoreVirtualTuple(slot);
 			pgstat_count_heap_fetch(aocsBitmapScan->rs_base.rs_rd);
+			aocoFetchDesc->visibilityMap.visimapStore.snapshot = InvalidSnapshot;
 
 			return true;
 		}
 	}
-
+	aocoFetchDesc->visibilityMap.visimapStore.snapshot = InvalidSnapshot;
 	/* Done with this block */
 	return false;
 }

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2281,7 +2281,7 @@ appendonly_fetch_init(Relation relation,
 						   aoFormData.visimaprelid,
 						   aoFormData.visimapidxid,
 						   AccessShareLock,
-						   appendOnlyMetaDataSnapshot);
+						   InvalidSnapshot);
 
 	return aoFetchDesc;
 

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1978,6 +1978,8 @@ appendonly_scan_bitmap_next_tuple(TableScanDesc scan,
 
 	}
 
+	aoscan->aofetch->visibilityMap.visimapStore.snapshot = aoscan->appendOnlyMetaDataSnapshot;
+
 	ExecClearTuple(slot);
 
 	/* ntuples == -1 indicates a lossy page */
@@ -2011,11 +2013,12 @@ appendonly_scan_bitmap_next_tuple(TableScanDesc scan,
 		{
 			/* OK to return this tuple */
 			pgstat_count_heap_fetch(aoscan->aos_rd);
+			aoscan->aofetch->visibilityMap.visimapStore.snapshot = InvalidSnapshot;
 
 			return true;
 		}
 	}
-
+	aoscan->aofetch->visibilityMap.visimapStore.snapshot = InvalidSnapshot;
 	/* Done with this block */
 	return false;
 }

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -545,7 +545,11 @@ appendonly_index_fetch_tuple(struct IndexFetchTableData *scan,
 	 */
 	Assert(aoscan->aofetch->snapshot == snapshot);
 
+	aoscan->aofetch->visibilityMap.visimapStore.snapshot = snapshot;
+
 	appendonly_fetch(aoscan->aofetch, (AOTupleId *) tid, slot);
+
+	aoscan->aofetch->visibilityMap.visimapStore.snapshot = InvalidSnapshot;
 
 	return !TupIsNull(slot);
 }

--- a/src/test/regress/input/constraints.source
+++ b/src/test/regress/input/constraints.source
@@ -591,3 +591,35 @@ DROP DOMAIN constraint_comments_dom;
 
 DROP ROLE regress_constraint_comments;
 DROP ROLE regress_constraint_comments_noaccess;
+
+--
+-- EXCLUDE constraints for AO
+--
+CREATE TABLE test_exclude_ao(
+  id int4,
+  room int4range,
+  EXCLUDE USING gist (room WITH =)
+) USING AO_ROW  DISTRIBUTED REPLICATED;
+INSERT INTO test_exclude_ao VALUES(1, int4range(123, 123, '[]'));
+
+-- conflicting key value violates exclusion constraint
+-- expected conflicting key error without other exception happen
+INSERT INTO test_exclude_ao VALUES(1, int4range(123, 123, '[]'));
+
+DROP TABLE test_exclude_ao;
+
+--
+-- EXCLUDE constraints for AOCS
+--
+CREATE TABLE test_exclude_aocs(
+  id int4,
+  room int4range,
+  EXCLUDE USING gist (room WITH =)
+) USING AO_COLUMN  DISTRIBUTED REPLICATED;
+INSERT INTO test_exclude_aocs VALUES(1, int4range(123, 123, '[]'));
+
+-- conflicting key value violates exclusion constraint
+-- expected conflicting key error without other exception happen
+INSERT INTO test_exclude_aocs VALUES(1, int4range(123, 123, '[]'));
+
+DROP TABLE test_exclude_aocs;

--- a/src/test/regress/output/constraints.source
+++ b/src/test/regress/output/constraints.source
@@ -779,3 +779,33 @@ DROP TABLE constraint_comments_tbl;
 DROP DOMAIN constraint_comments_dom;
 DROP ROLE regress_constraint_comments;
 DROP ROLE regress_constraint_comments_noaccess;
+--
+-- EXCLUDE constraints for AO
+--
+CREATE TABLE test_exclude_ao(
+  id int4,
+  room int4range,
+  EXCLUDE USING gist (room WITH =)
+) USING AO_ROW  DISTRIBUTED REPLICATED;
+INSERT INTO test_exclude_ao VALUES(1, int4range(123, 123, '[]'));
+-- conflicting key value violates exclusion constraint
+-- expected conflicting key error without other exception happen
+INSERT INTO test_exclude_ao VALUES(1, int4range(123, 123, '[]'));
+DETAIL:  Key (room)=([123,124)) conflicts with existing key (room)=([123,124)).
+ERROR:  conflicting key value violates exclusion constraint "test_exclude_ao_room_excl"
+DROP TABLE test_exclude_ao;
+--
+-- EXCLUDE constraints for AOCS
+--
+CREATE TABLE test_exclude_aocs(
+  id int4,
+  room int4range,
+  EXCLUDE USING gist (room WITH =)
+) USING AO_COLUMN  DISTRIBUTED REPLICATED;
+INSERT INTO test_exclude_aocs VALUES(1, int4range(123, 123, '[]'));
+-- conflicting key value violates exclusion constraint
+-- expected conflicting key error without other exception happen
+INSERT INTO test_exclude_aocs VALUES(1, int4range(123, 123, '[]'));
+DETAIL:  Key (room)=([123,124)) conflicts with existing key (room)=([123,124)).
+ERROR:  conflicting key value violates exclusion constraint "test_exclude_aocs_room_excl"
+DROP TABLE test_exclude_aocs;


### PR DESCRIPTION
<!--Thank you for contributing!-->

<!--In case of an existing issue or discussions, please reference it-->
closes: #93
<!--Remove this section if no corresponding issue.-->

---

### Change logs
This bug comes from AppendOnlyVisimapStore_Init calling RegisterSnapshot in appendonly_fetch_init, which creates a deep copy of the current snapshot. Therefore, when a constraint is violated(see function check_exclusion_or_unique_constraint in detail), EROOR will be performed directly, but UnregisterSnapshot in AppendOnlyVisimap_Finish is not called. Therefore, an Asset error will occur when the resource is finally recycled.

In order to solve this problem: directly delete the RegisterSnapshot in AppendOnlyVisimapStore_Init which affects the deletion logic of the AO table. So we did not change AppendOnlyVisimap_Init, but passed in an InvalidSnapshot during initialization. And at the same time, in order to ensure that Visimap can get the correct snapshot. Before the execution of appendonly_fetch, the snapshot of visimap is assigned and deleted afterwards. Note that the free of the snapshot is still done by who malloc.


### Why are the changes needed?
See the issue for detail 

### Does this PR introduce any user-facing change?
NO

### How was this patch tested?

Still wait for adding

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [x] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [x] Sign the Contributor License Agreement as prompted for your first-time contribution.
- [x] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [x] Document changes.
- [x] Add tests for the change
- [x] Pass `make installcheck`
- [x] Pass `make -C src/test installcheck-cbdb-parallel`
- [x] Feel free to @cloudberrydb/dev team for review and approval when your PR is ready🥳
