### PR TITLE
Fix Bitmap Index Scan locus is NULL

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -4194,6 +4194,7 @@ create_bitmap_subplan(PlannerInfo *root, Path *bitmapqual,
 		plan->plan_width = 0;	/* meaningless */
 		plan->parallel_aware = false;
 		plan->parallel_safe = ipath->path.parallel_safe;
+		plan->locustype = ipath->path.locus.locustype;
 		/* Extract original index clauses, actual index quals, relevant ECs */
 		subquals = NIL;
 		subindexquals = NIL;

--- a/src/test/regress/expected/gp_parallel.out
+++ b/src/test/regress/expected/gp_parallel.out
@@ -224,7 +224,7 @@ explain(locus, costs off) select c2 from t1;
          Locus: HashedWorkers
          Parallel Workers: 2
          ->  Bitmap Index Scan on t1_c2_idx
-               Locus: NULL
+               Locus: Hashed
  Optimizer: Postgres query optimizer
 (8 rows)
 
@@ -243,7 +243,7 @@ explain(locus, costs off) select count(c2) from t1;
                      Locus: HashedWorkers
                      Parallel Workers: 2
                      ->  Bitmap Index Scan on t1_c2_idx
-                           Locus: NULL
+                           Locus: Hashed
  Optimizer: Postgres query optimizer
 (13 rows)
 
@@ -266,7 +266,7 @@ explain(locus, costs off) select count(c2) from t1;
                ->  Bitmap Heap Scan on t1
                      Locus: Hashed
                      ->  Bitmap Index Scan on t1_c2_idx
-                           Locus: NULL
+                           Locus: Hashed
  Optimizer: Postgres query optimizer
 (11 rows)
 


### PR DESCRIPTION
create_bitmap_subplan() will try to convert subplan to a bitmap indexscan, add locus info for that.
```sql
                 QUERY PLAN
--------------------------------------------
 Gather Motion 6:1  (slice1; segments: 6)
   Locus: Entry
   ->  Parallel Bitmap Heap Scan on t1
         Locus: HashedWorkers
         Parallel Workers: 2
         ->  Bitmap Index Scan on t1_c2_idx
               Locus: Hashed
```
It's reasonable to eliminate `Parallel Workers` info. 
Because a Bitmap Index Scan under Parallel Bitmap Heap Scan will only be taken by one procress as the Postgres Doc: 
> In a parallel bitmap heap scan, one process is chosen as the leader. That process performs a scan of one or more indexes and builds a bitmap indicating which table blocks need to be visited. These blocks are then divided among the cooperating processes as in a parallel sequential scan.
In other words, the heap scan is performed in parallel, but the underlying index scan is not.

Authored-by: Zhang Mingli avamingli@gmail.com

<!--Thank you for contributing!-->

<!--In case of an existing issue or discussions, please reference it-->
closes: #86 
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [x] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [x] Sign the Contributor License Agreement as prompted for your first-time contribution.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [x] Add tests for the change
- [x] Pass `make installcheck`
- [x] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to @cloudberrydb/dev team for review and approval when your PR is ready🥳
