### PR TITLE
Feature: Introduce extra tableam hook routinue for catalog to replace direct heap function calls

### DIFF
--- a/contrib/pgrowlocks/pgrowlocks.c
+++ b/contrib/pgrowlocks/pgrowlocks.c
@@ -144,7 +144,7 @@ pgrowlocks(PG_FUNCTION_ARGS)
 
 	values = (char **) palloc(tupdesc->natts * sizeof(char *));
 
-	while ((tuple = heap_getnext(scan, ForwardScanDirection)) != NULL)
+	while ((tuple = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 	{
 		TM_Result	htsu;
 		TransactionId xmax;

--- a/contrib/pgstattuple/pgstattuple.c
+++ b/contrib/pgstattuple/pgstattuple.c
@@ -345,7 +345,7 @@ pgstat_heap(Relation rel, FunctionCallInfo fcinfo)
 	nblocks = hscan->rs_nblocks;	/* # blocks to be scanned */
 
 	/* scan the relation */
-	while ((tuple = heap_getnext(scan, ForwardScanDirection)) != NULL)
+	while ((tuple = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 	{
 		CHECK_FOR_INTERRUPTS();
 

--- a/gpcontrib/gp_replica_check/gp_replica_check.c
+++ b/gpcontrib/gp_replica_check/gp_replica_check.c
@@ -534,7 +534,7 @@ get_relfilenode_map()
 
 	pg_class = table_open(RelationRelationId, AccessShareLock);
 	scan = table_beginscan_catalog(pg_class, 0, NULL);
-	while((tup = heap_getnext(scan, ForwardScanDirection)) != NULL)
+	while((tup = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 	{
 		Form_pg_class classtuple = (Form_pg_class) GETSTRUCT(tup);
 

--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -535,7 +535,7 @@ MarkAOCSFileSegInfoAwaitingDrop(Relation prel, int segno)
 	 * LockRelationAppendOnlySegmentFile) we can use SnapshotNow.
 	 */
 	scan = table_beginscan_catalog(segrel, 0, NULL);
-	while (segno != tuple_segno && (oldtup = heap_getnext(scan, ForwardScanDirection)) != NULL)
+	while (segno != tuple_segno && (oldtup = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 	{
 		tuple_segno = DatumGetInt32(fastgetattr(oldtup, Anum_pg_aocs_segno, tupdesc, &isNull));
 		if (isNull)
@@ -569,7 +569,7 @@ MarkAOCSFileSegInfoAwaitingDrop(Relation prel, int segno)
 
 	newtup = heap_modify_tuple(oldtup, tupdesc, d, null, repl);
 
-	simple_heap_update(segrel, &oldtup->t_self, newtup);
+	simple_table_tuple_update(segrel, &oldtup->t_self, newtup);
 
 	pfree(newtup);
 
@@ -628,7 +628,7 @@ ClearAOCSFileSegInfo(Relation prel, int segno)
 	 * LockRelationAppendOnlySegmentFile) we can use SnapshotNow.
 	 */
 	scan = table_beginscan_catalog(segrel, 0, NULL);
-	while (segno != tuple_segno && (oldtup = heap_getnext(scan, ForwardScanDirection)) != NULL)
+	while (segno != tuple_segno && (oldtup = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 	{
 		tuple_segno = DatumGetInt32(fastgetattr(oldtup, Anum_pg_aocs_segno, tupdesc, &isNull));
 		if (isNull)
@@ -681,7 +681,7 @@ ClearAOCSFileSegInfo(Relation prel, int segno)
 
 	newtup = heap_modify_tuple(oldtup, tupdesc, d, null, repl);
 
-	simple_heap_update(segrel, &oldtup->t_self, newtup);
+	simple_table_tuple_update(segrel, &oldtup->t_self, newtup);
 
 	pfree(newtup);
 	pfree(vpinfo);
@@ -844,7 +844,7 @@ UpdateAOCSFileSegInfo(AOCSInsertDesc idesc)
 
 	newtup = heap_modify_tuple(oldtup, tupdesc, d, null, repl);
 
-	simple_heap_update(segrel, &oldtup->t_self, newtup);
+	simple_table_tuple_update(segrel, &oldtup->t_self, newtup);
 
 	pfree(newtup);
 	pfree(vpinfo);
@@ -992,7 +992,7 @@ AOCSFileSegInfoAddVpe(Relation prel, int32 segno,
 
 	newtup = heap_modify_tuple(oldtup, tupdesc, d, null, repl);
 
-	simple_heap_update(segrel, &oldtup->t_self, newtup);
+	simple_table_tuple_update(segrel, &oldtup->t_self, newtup);
 
 	pfree(newtup);
 	pfree(newvpinfo);
@@ -1090,7 +1090,7 @@ AOCSFileSegInfoAddCount(Relation prel, int32 segno,
 
 	newtup = heap_modify_tuple(oldtup, tupdesc, d, null, repl);
 
-	simple_heap_update(segrel, &oldtup->t_self, newtup);
+	simple_table_tuple_update(segrel, &oldtup->t_self, newtup);
 
 	heap_freetuple(newtup);
 

--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -631,7 +631,7 @@ ClearFileSegInfo(Relation parentrel, int segno)
 	pg_aoseg_dsc = RelationGetDescr(pg_aoseg_rel);
 
 	aoscan = table_beginscan_catalog(pg_aoseg_rel, 0, NULL);
-	while (segno != tuple_segno && (tuple = heap_getnext(aoscan, ForwardScanDirection)) != NULL)
+	while (segno != tuple_segno && (tuple = table_scan_getnext(aoscan, ForwardScanDirection)) != NULL)
 	{
 		tuple_segno = DatumGetInt32(fastgetattr(tuple, Anum_pg_aoseg_segno, pg_aoseg_dsc, &isNull));
 		if (isNull)
@@ -672,7 +672,7 @@ ClearFileSegInfo(Relation parentrel, int segno)
 	new_tuple = heap_modify_tuple(tuple, pg_aoseg_dsc, new_record,
 								  new_record_nulls, new_record_repl);
 
-	simple_heap_update(pg_aoseg_rel, &tuple->t_self, new_tuple);
+	simple_table_tuple_update(pg_aoseg_rel, &tuple->t_self, new_tuple);
 	heap_freetuple(new_tuple);
 
 	table_endscan(aoscan);
@@ -765,7 +765,7 @@ UpdateFileSegInfo_internal(Relation parentrel,
 	pg_aoseg_dsc = RelationGetDescr(pg_aoseg_rel);
 
 	aoscan = table_beginscan_catalog(pg_aoseg_rel, 0, NULL);
-	while (segno != tuple_segno && (tuple = heap_getnext(aoscan, ForwardScanDirection)) != NULL)
+	while (segno != tuple_segno && (tuple = table_scan_getnext(aoscan, ForwardScanDirection)) != NULL)
 	{
 		tuple_segno = DatumGetInt32(fastgetattr(tuple, Anum_pg_aoseg_segno, pg_aoseg_dsc, &isNull));
 		if (isNull)
@@ -920,7 +920,7 @@ UpdateFileSegInfo_internal(Relation parentrel,
 	new_tuple = heap_modify_tuple(tuple, pg_aoseg_dsc, new_record,
 								  new_record_nulls, new_record_repl);
 
-	simple_heap_update(pg_aoseg_rel, &tuple->t_self, new_tuple);
+	simple_table_tuple_update(pg_aoseg_rel, &tuple->t_self, new_tuple);
 
 	heap_freetuple(new_tuple);
 

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1825,7 +1825,7 @@ appendonly_index_validate_scan(Relation heapRelation,
 	/*
 	 * Scan all tuples matching the snapshot.
 	 */
-	while ((heapTuple = heap_getnext(scan, ForwardScanDirection)) != NULL)
+	while ((heapTuple = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 	{
 		ItemPointer heapcursor = &heapTuple->t_self;
 		ItemPointerData rootTuple;

--- a/src/backend/access/bitmap/bitmapattutil.c
+++ b/src/backend/access/bitmap/bitmapattutil.c
@@ -339,7 +339,7 @@ _bitmap_insert_lov(Relation lovHeap, Relation lovIndex, Datum *datum,
 
 	/* insert this tuple into the heap */
 	tuple = heap_form_tuple(tupDesc, datum, nulls);
-	frozen_heap_insert(lovHeap, tuple);
+	frozen_table_tuple_insert(lovHeap, tuple);
 
 	/* insert a new tuple into the index */
 	indexDatum = palloc0((tupDesc->natts - 2) * sizeof(Datum));

--- a/src/backend/access/common/toast_internals.c
+++ b/src/backend/access/common/toast_internals.c
@@ -438,7 +438,7 @@ toast_delete_datum(Relation rel, Datum value, bool is_speculative)
 		if (is_speculative)
 			heap_abort_speculative(toastrel, &toasttup->t_self);
 		else
-			simple_heap_delete(toastrel, &toasttup->t_self);
+			simple_table_tuple_delete(toastrel, &toasttup->t_self);
 	}
 
 	/*

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -1395,6 +1395,10 @@ heap_endscan(TableScanDesc sscan)
 	pfree(scan);
 }
 
+/*
+ * NB: We no longer assume that catalog use heap. To avoid tableam
+ * errors, please use table_scan_getnext() instead.
+ */
 HeapTuple
 heap_getnext(TableScanDesc sscan, ScanDirection direction)
 {
@@ -2391,6 +2395,9 @@ heap_prepare_insert(Relation relation, HeapTuple tup, TransactionId xid,
 /*
  *	heap_multi_insert	- insert multiple tuples into a heap
  *
+ * NB: We no longer assume that catalog use heap. To avoid tableam
+ * errors, please use table_multi_insert() instead.
+ *
  * This is like heap_insert(), but inserts multiple tuples in one operation.
  * That's faster than calling heap_insert() in a loop, because when multiple
  * tuples can be inserted on a single page, we can write just a single WAL
@@ -2738,6 +2745,9 @@ heap_multi_insert(Relation relation, TupleTableSlot **slots, int ntuples,
 /*
  *	simple_heap_insert - insert a tuple
  *
+ * NB: We no longer assume that catalog use heap. To avoid tableam
+ * errors, please use simple_table_tuple_insert() instead.
+ *
  * Currently, this routine differs from heap_insert only in supplying
  * a default command ID and not allowing access to the speedup options.
  *
@@ -2753,6 +2763,9 @@ simple_heap_insert(Relation relation, HeapTuple tup)
 
 /*
  *	frozen_heap_insert - insert a tuple and freeze it (always visible).
+ *
+ * NB: We no longer assume that catalog use heap. To avoid tableam
+ * errors, please use frozen_table_tuple_insert() instead.
  *
  * Currently, this routine differs from heap_insert in supplying
  * a default command ID and a frozen transaction id. Also, the committed
@@ -3224,6 +3237,9 @@ l1:
 
 /*
  *	simple_heap_delete - delete a tuple
+ *
+ * NB: We no longer assume that catalog use heap. To avoid tableam
+ * errors, please use simple_table_tuple_delete() instead.
  *
  * This routine may be used to delete a tuple when concurrent updates of
  * the target tuple are not expected (for example, because we have a lock
@@ -4342,6 +4358,9 @@ HeapDetermineColumnsInfo(Relation relation,
 
 /*
  *	simple_heap_update - replace a tuple
+ *
+ * NB: We no longer assume that catalog use heap. To avoid tableam
+ * errors, please use simple_table_tuple_update() instead.
  *
  * This routine may be used to update a tuple when concurrent updates of
  * the target tuple are not expected (for example, because we have a lock
@@ -6173,6 +6192,9 @@ heap_abort_speculative(Relation relation, ItemPointer tid)
 
 /*
  * heap_inplace_update - update a tuple "in place" (ie, overwrite it)
+ *
+ * NB: We no longer assume that catalog use heap. To avoid tableam
+ * errors, please use inplace_table_tuple_update() instead.
  *
  * Overwriting violates both MVCC and transactional safety, so the uses
  * of this function in Postgres are extremely limited.  Nonetheless we

--- a/src/backend/access/heap/heapam_handler.c
+++ b/src/backend/access/heap/heapam_handler.c
@@ -1335,7 +1335,7 @@ heapam_index_build_range_scan(Relation heapRelation,
 	/*
 	 * Scan all tuples in the base relation.
 	 */
-	while ((heapTuple = heap_getnext(scan, ForwardScanDirection)) != NULL)
+	while ((heapTuple = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 	{
 		bool		tupleIsAlive;
 
@@ -1817,7 +1817,7 @@ heapam_index_validate_scan(Relation heapRelation,
 	/*
 	 * Scan all tuples matching the snapshot.
 	 */
-	while ((heapTuple = heap_getnext(scan, ForwardScanDirection)) != NULL)
+	while ((heapTuple = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 	{
 		ItemPointer heapcursor = &heapTuple->t_self;
 		ItemPointerData rootTuple;

--- a/src/backend/bootstrap/bootstrap.c
+++ b/src/backend/bootstrap/bootstrap.c
@@ -831,7 +831,7 @@ InsertOneTuple(void)
 	tuple = heap_form_tuple(tupDesc, values, Nulls);
 	pfree(tupDesc);				/* just free's tupDesc, not the attrtypes */
 
-	simple_heap_insert(boot_reldesc, tuple);
+	simple_table_tuple_insert(boot_reldesc, tuple);
 	heap_freetuple(tuple);
 	elog(DEBUG4, "row inserted");
 
@@ -928,7 +928,7 @@ populate_typ_list(void)
 	rel = table_open(TypeRelationId, NoLock);
 	scan = table_beginscan_catalog(rel, 0, NULL);
 	old = MemoryContextSwitchTo(TopMemoryContext);
-	while ((tup = heap_getnext(scan, ForwardScanDirection)) != NULL)
+	while ((tup = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 	{
 		Form_pg_type typForm = (Form_pg_type) GETSTRUCT(tup);
 		struct typmap *newtyp;

--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -958,7 +958,7 @@ objectsInSchemaToOids(ObjectType objtype, List *nspnames)
 					rel = table_open(ProcedureRelationId, AccessShareLock);
 					scan = table_beginscan_catalog(rel, keycount, key);
 
-					while ((tuple = heap_getnext(scan, ForwardScanDirection)) != NULL)
+					while ((tuple = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 					{
 						Oid			oid = ((Form_pg_proc) GETSTRUCT(tuple))->oid;
 
@@ -1005,7 +1005,7 @@ getRelationsInNamespace(Oid namespaceId, char relkind)
 	rel = table_open(RelationRelationId, AccessShareLock);
 	scan = table_beginscan_catalog(rel, 2, key);
 
-	while ((tuple = heap_getnext(scan, ForwardScanDirection)) != NULL)
+	while ((tuple = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 	{
 		Oid			oid = ((Form_pg_class) GETSTRUCT(tuple))->oid;
 

--- a/src/backend/catalog/aoseg.c
+++ b/src/backend/catalog/aoseg.c
@@ -178,7 +178,7 @@ AlterTableCreateAoSegTable(Oid relOid)
 	else
 	{
 		/* While bootstrapping, we cannot UPDATE, so overwrite in-place */
-		heap_inplace_update(class_rel, reltup);
+		inplace_table_tuple_update(class_rel, reltup);
 	}
 
 	heap_freetuple(reltup);

--- a/src/backend/catalog/gp_fastsequence.c
+++ b/src/backend/catalog/gp_fastsequence.c
@@ -165,7 +165,7 @@ insert_or_update_fastsequence(Relation gp_fastsequence_rel,
 		newTuple = heap_form_tuple(tupleDesc, values, nulls);
 		newTuple->t_data->t_ctid = oldTuple->t_data->t_ctid;
 		newTuple->t_self = oldTuple->t_self;
-		heap_inplace_update(gp_fastsequence_rel, newTuple);
+		inplace_table_tuple_update(gp_fastsequence_rel, newTuple);
 
 		heap_freetuple(newTuple);
 	}

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -2996,7 +2996,7 @@ index_update_stats(Relation rel,
 					ObjectIdGetDatum(relid));
 
 		pg_class_scan = table_beginscan_catalog(pg_class, 1, key);
-		tuple = heap_getnext(pg_class_scan, ForwardScanDirection);
+		tuple = table_scan_getnext(pg_class_scan, ForwardScanDirection);
 		tuple = heap_copytuple(tuple);
 		table_endscan(pg_class_scan);
 	}
@@ -3069,7 +3069,7 @@ index_update_stats(Relation rel,
 	 */
 	if (dirty)
 	{
-		heap_inplace_update(pg_class, tuple);
+		inplace_table_tuple_update(pg_class, tuple);
 		/* the above sends a cache inval message */
 	}
 	else

--- a/src/backend/catalog/indexing.c
+++ b/src/backend/catalog/indexing.c
@@ -227,7 +227,7 @@ CatalogTupleInsert(Relation heapRel, HeapTuple tup)
 
 	indstate = CatalogOpenIndexes(heapRel);
 
-	simple_heap_insert(heapRel, tup);
+	simple_table_tuple_insert(heapRel, tup);
 
 	CatalogIndexInsert(indstate, tup);
 	CatalogCloseIndexes(indstate);
@@ -247,7 +247,7 @@ CatalogTupleInsertWithInfo(Relation heapRel, HeapTuple tup,
 {
 	CatalogTupleCheckConstraints(heapRel, tup);
 
-	simple_heap_insert(heapRel, tup);
+	simple_table_tuple_insert(heapRel, tup);
 
 	CatalogIndexInsert(indstate, tup);
 }
@@ -266,8 +266,8 @@ CatalogTuplesMultiInsertWithInfo(Relation heapRel, TupleTableSlot **slot,
 	if (ntuples <= 0)
 		return;
 
-	heap_multi_insert(heapRel, slot, ntuples,
-					  GetCurrentCommandId(true), 0, NULL);
+	table_multi_insert(heapRel, slot, ntuples,
+					   GetCurrentCommandId(true), 0, NULL);
 
 	/*
 	 * There is no equivalent to heap_multi_insert for the catalog indexes, so
@@ -307,7 +307,7 @@ CatalogTupleUpdate(Relation heapRel, ItemPointer otid, HeapTuple tup)
 
 	indstate = CatalogOpenIndexes(heapRel);
 
-	simple_heap_update(heapRel, otid, tup);
+	simple_table_tuple_update(heapRel, otid, tup);
 
 	CatalogIndexInsert(indstate, tup);
 	CatalogCloseIndexes(indstate);
@@ -327,7 +327,7 @@ CatalogTupleUpdateWithInfo(Relation heapRel, ItemPointer otid, HeapTuple tup,
 {
 	CatalogTupleCheckConstraints(heapRel, tup);
 
-	simple_heap_update(heapRel, otid, tup);
+	simple_table_tuple_update(heapRel, otid, tup);
 
 	CatalogIndexInsert(indstate, tup);
 }
@@ -350,7 +350,7 @@ CatalogTupleUpdateWithInfo(Relation heapRel, ItemPointer otid, HeapTuple tup,
 void
 CatalogTupleDelete(Relation heapRel, ItemPointer tid)
 {
-	simple_heap_delete(heapRel, tid);
+	simple_table_tuple_delete(heapRel, tid);
 }
 
 /*
@@ -365,7 +365,7 @@ CatalogTupleInsertFrozen(Relation heapRel, HeapTuple tup)
 
 	indstate = CatalogOpenIndexes(heapRel);
 
-	frozen_heap_insert(heapRel, tup);
+	frozen_table_tuple_insert(heapRel, tup);
 
 	CatalogIndexInsert(indstate, tup);
 	CatalogCloseIndexes(indstate);

--- a/src/backend/catalog/pg_appendonly.c
+++ b/src/backend/catalog/pg_appendonly.c
@@ -422,7 +422,7 @@ RemoveAppendonlyEntry(Oid relid)
 	/*
 	 * Delete the appendonly table entry from the catalog (pg_appendonly).
 	 */
-	simple_heap_delete(pg_appendonly_rel, &tuple->t_self);
+	simple_table_tuple_delete(pg_appendonly_rel, &tuple->t_self);
 	
 	/* Finish up scan and close appendonly catalog. */
 	systable_endscan(scan);
@@ -574,8 +574,8 @@ SwapAppendonlyEntries(Oid entryRelId1, Oid entryRelId2)
 	}
 
 	/* Since gp_fastsequence entry is referenced by aosegrelid, it rides along  */
-	simple_heap_delete(pg_appendonly_rel, &tupleCopy1->t_self);
-	simple_heap_delete(pg_appendonly_rel, &tupleCopy2->t_self);
+	simple_table_tuple_delete(pg_appendonly_rel, &tupleCopy1->t_self);
+	simple_table_tuple_delete(pg_appendonly_rel, &tupleCopy2->t_self);
 
 	/*
 	 * (Re)insert.

--- a/src/backend/catalog/pg_attribute_encoding.c
+++ b/src/backend/catalog/pg_attribute_encoding.c
@@ -309,7 +309,7 @@ RemoveAttributeEncodingsByRelid(Oid relid)
 							  NULL, 1, &skey);
 	while (HeapTupleIsValid(tup = systable_getnext(scan)))
 	{
-		simple_heap_delete(rel, &tup->t_self);
+		simple_table_tuple_delete(rel, &tup->t_self);
 	}
 
 	systable_endscan(scan);

--- a/src/backend/catalog/pg_db_role_setting.c
+++ b/src/backend/catalog/pg_db_role_setting.c
@@ -317,7 +317,7 @@ DropSetting(Oid databaseid, Oid roleid)
 	}
 
 	scan = table_beginscan_catalog(relsetting, numkeys, keys);
-	while (HeapTupleIsValid(tup = heap_getnext(scan, ForwardScanDirection)))
+	while (HeapTupleIsValid(tup = table_scan_getnext(scan, ForwardScanDirection)))
 	{
 		CatalogTupleDelete(relsetting, &tup->t_self);
 	}

--- a/src/backend/catalog/pg_proc_callback.c
+++ b/src/backend/catalog/pg_proc_callback.c
@@ -64,7 +64,7 @@ deleteProcCallbacks(Oid profnoid)
 							  NULL, 1, &skey);
 
 	while (HeapTupleIsValid(tup = systable_getnext(scan)))
-		simple_heap_delete(rel, &tup->t_self);
+		simple_table_tuple_delete(rel, &tup->t_self);
 
 	systable_endscan(scan);
 

--- a/src/backend/catalog/pg_publication.c
+++ b/src/backend/catalog/pg_publication.c
@@ -432,7 +432,7 @@ GetAllTablesPublicationRelations(bool pubviaroot)
 
 	scan = table_beginscan_catalog(classRel, 1, key);
 
-	while ((tuple = heap_getnext(scan, ForwardScanDirection)) != NULL)
+	while ((tuple = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 	{
 		Form_pg_class relForm = (Form_pg_class) GETSTRUCT(tuple);
 		Oid			relid = relForm->oid;
@@ -453,7 +453,7 @@ GetAllTablesPublicationRelations(bool pubviaroot)
 
 		scan = table_beginscan_catalog(classRel, 1, key);
 
-		while ((tuple = heap_getnext(scan, ForwardScanDirection)) != NULL)
+		while ((tuple = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 		{
 			Form_pg_class relForm = (Form_pg_class) GETSTRUCT(tuple);
 			Oid			relid = relForm->oid;

--- a/src/backend/catalog/pg_subscription.c
+++ b/src/backend/catalog/pg_subscription.c
@@ -412,7 +412,7 @@ RemoveSubscriptionRel(Oid subid, Oid relid)
 
 	/* Do the search and delete what we found. */
 	scan = table_beginscan_catalog(rel, nkeys, skey);
-	while (HeapTupleIsValid(tup = heap_getnext(scan, ForwardScanDirection)))
+	while (HeapTupleIsValid(tup = table_scan_getnext(scan, ForwardScanDirection)))
 	{
 		Form_pg_subscription_rel subrel;
 

--- a/src/backend/catalog/pg_type.c
+++ b/src/backend/catalog/pg_type.c
@@ -156,7 +156,7 @@ remove_type_encoding(Oid typid)
 							   NULL, 1, &scankey);
 	while((tuple = systable_getnext(sscan)) != NULL)
 	{
-		simple_heap_delete(rel, &tuple->t_self);
+		simple_table_tuple_delete(rel, &tuple->t_self);
 	}
 	systable_endscan(sscan);
 

--- a/src/backend/catalog/toasting.c
+++ b/src/backend/catalog/toasting.c
@@ -380,7 +380,7 @@ create_toast_table(Relation rel, Oid toastOid, Oid toastIndexOid,
 	else
 	{
 		/* While bootstrapping, we cannot UPDATE, so overwrite in-place */
-		heap_inplace_update(class_rel, reltup);
+		inplace_table_tuple_update(class_rel, reltup);
 	}
 
 	heap_freetuple(reltup);

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -1049,7 +1049,7 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 				{
 					aorel = table_open(AppendOnlyRelationId, RowExclusiveLock);
 					aoform->segfilecount = ao_segfile_count;
-					heap_inplace_update(aorel, aotup);
+					inplace_table_tuple_update(aorel, aotup);
 					table_close(aorel, RowExclusiveLock);
 				}
 			}

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -1709,7 +1709,7 @@ get_tables_to_cluster(MemoryContext cluster_context)
 				BTEqualStrategyNumber, F_BOOLEQ,
 				BoolGetDatum(true));
 	scan = table_beginscan_catalog(indRelation, 1, &entry);
-	while ((indexTuple = heap_getnext(scan, ForwardScanDirection)) != NULL)
+	while ((indexTuple = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 	{
 		index = (Form_pg_index) GETSTRUCT(indexTuple);
 

--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -692,7 +692,7 @@ createdb(ParseState *pstate, const CreatedbStmt *stmt)
 		 */
 		rel = table_open(TableSpaceRelationId, AccessShareLock);
 		scan = table_beginscan_catalog(rel, 0, NULL);
-		while ((tuple = heap_getnext(scan, ForwardScanDirection)) != NULL)
+		while ((tuple = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 		{
 			Form_pg_tablespace spaceform = (Form_pg_tablespace) GETSTRUCT(tuple);
 			Oid			srctablespace = spaceform->oid;
@@ -2162,7 +2162,7 @@ remove_dbtablespaces(Oid db_id)
 
 	rel = table_open(TableSpaceRelationId, AccessShareLock);
 	scan = table_beginscan_catalog(rel, 0, NULL);
-	while ((tuple = heap_getnext(scan, ForwardScanDirection)) != NULL)
+	while ((tuple = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 	{
 		Form_pg_tablespace spcform = (Form_pg_tablespace) GETSTRUCT(tuple);
 		Oid			dsttablespace = spcform->oid;
@@ -2248,7 +2248,7 @@ check_db_file_conflict(Oid db_id)
 
 	rel = table_open(TableSpaceRelationId, AccessShareLock);
 	scan = table_beginscan_catalog(rel, 0, NULL);
-	while ((tuple = heap_getnext(scan, ForwardScanDirection)) != NULL)
+	while ((tuple = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 	{
 		Form_pg_tablespace spcform = (Form_pg_tablespace) GETSTRUCT(tuple);
 		Oid			dsttablespace = spcform->oid;

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -3494,7 +3494,7 @@ ReindexMultipleTables(ReindexStmt *stmt, ReindexParams *params)
 	 */
 	relationRelation = table_open(RelationRelationId, AccessShareLock);
 	scan = table_beginscan_catalog(relationRelation, num_keys, scan_keys);
-	while ((tuple = heap_getnext(scan, ForwardScanDirection)) != NULL)
+	while ((tuple = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 	{
 		Form_pg_class classtuple = (Form_pg_class) GETSTRUCT(tuple);
 		Oid			relid = classtuple->oid;

--- a/src/backend/commands/queue.c
+++ b/src/backend/commands/queue.c
@@ -626,7 +626,7 @@ AlterResqueueCapabilityEntry(Oid queueid,
 					((Form_pg_resqueuecapability) GETSTRUCT(tuple))->restypid)
 				{
 					/* no "off" setting -- just remove entry */
-					simple_heap_delete(rel, &tuple->t_self);
+					simple_table_tuple_delete(rel, &tuple->t_self);
 					ii++;
 				}
 			}
@@ -1501,7 +1501,7 @@ DropQueue(DropQueueStmt *stmt)
 	/*
 	 * Delete the queue from the catalog.
 	 */
-	simple_heap_delete(pg_resqueue_rel, &tuple->t_self);
+	simple_table_tuple_delete(pg_resqueue_rel, &tuple->t_self);
 
 	systable_endscan(sscan);
 
@@ -1560,7 +1560,7 @@ DropQueue(DropQueueStmt *stmt)
 							   true, NULL, 1, &scankey);
 
 	while ((tuple = systable_getnext(sscan)) != NULL)
-		simple_heap_delete(resqueueCapabilityRel, &tuple->t_self);
+		simple_table_tuple_delete(resqueueCapabilityRel, &tuple->t_self);
 
 	systable_endscan(sscan);
 

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -340,7 +340,7 @@ DropResourceGroup(DropResourceGroupStmt *stmt)
 	/*
 	 * Delete the resource group from the catalog.
 	 */
-	simple_heap_delete(pg_resgroup_rel, &tuple->t_self);
+	simple_table_tuple_delete(pg_resgroup_rel, &tuple->t_self);
 	systable_endscan(sscan);
 	heap_close(pg_resgroup_rel, NoLock);
 
@@ -1473,7 +1473,7 @@ deleteResgroupCapabilities(Oid groupid)
 							   true, NULL, 1, &scankey);
 
 	while ((tuple = systable_getnext(sscan)) != NULL)
-		simple_heap_delete(resgroup_capability_rel, &tuple->t_self);
+		simple_table_tuple_delete(resgroup_capability_rel, &tuple->t_self);
 
 	systable_endscan(sscan);
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1841,7 +1841,7 @@ ao_aux_tables_safe_truncate(Relation rel)
 	{
 		aorel = table_open(AppendOnlyRelationId, RowExclusiveLock);
 		aoform->segfilecount = 0;
-		heap_inplace_update(aorel, aotup);
+		inplace_table_tuple_update(aorel, aotup);
 		table_close(aorel, RowExclusiveLock);
 	}
 	ReleaseSysCache(aotup);
@@ -7754,7 +7754,7 @@ find_typed_table_dependencies(Oid typeOid, const char *typeName, DropBehavior be
 
 	scan = table_beginscan_catalog(classRel, 1, key);
 
-	while ((tuple = heap_getnext(scan, ForwardScanDirection)) != NULL)
+	while ((tuple = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 	{
 		Form_pg_class classform = (Form_pg_class) GETSTRUCT(tuple);
 
@@ -16100,7 +16100,7 @@ AlterTableMoveAll(AlterTableMoveAllStmt *stmt)
 
 	rel = table_open(RelationRelationId, AccessShareLock);
 	scan = table_beginscan_catalog(rel, 1, key);
-	while ((tuple = heap_getnext(scan, ForwardScanDirection)) != NULL)
+	while ((tuple = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 	{
 		Form_pg_class relForm = (Form_pg_class) GETSTRUCT(tuple);
 		Oid			relOid = relForm->oid;

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -633,7 +633,7 @@ DropTableSpace(DropTableSpaceStmt *stmt)
 				BTEqualStrategyNumber, F_NAMEEQ,
 				CStringGetDatum(tablespacename));
 	scandesc = table_beginscan_catalog(rel, 1, entry);
-	tuple = heap_getnext(scandesc, ForwardScanDirection);
+	tuple = table_scan_getnext(scandesc, ForwardScanDirection);
 
 	if (!HeapTupleIsValid(tuple))
 	{
@@ -1343,7 +1343,7 @@ RenameTableSpace(const char *oldname, const char *newname)
 				BTEqualStrategyNumber, F_NAMEEQ,
 				CStringGetDatum(oldname));
 	scan = table_beginscan_catalog(rel, 1, entry);
-	tup = heap_getnext(scan, ForwardScanDirection);
+	tup = table_scan_getnext(scan, ForwardScanDirection);
 	if (!HeapTupleIsValid(tup))
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
@@ -1385,7 +1385,7 @@ RenameTableSpace(const char *oldname, const char *newname)
 				BTEqualStrategyNumber, F_NAMEEQ,
 				CStringGetDatum(newname));
 	scan = table_beginscan_catalog(rel, 1, entry);
-	tup = heap_getnext(scan, ForwardScanDirection);
+	tup = table_scan_getnext(scan, ForwardScanDirection);
 	if (HeapTupleIsValid(tup))
 		ereport(ERROR,
 				(errcode(ERRCODE_DUPLICATE_OBJECT),
@@ -1443,7 +1443,7 @@ AlterTableSpaceOptions(AlterTableSpaceOptionsStmt *stmt)
 				BTEqualStrategyNumber, F_NAMEEQ,
 				CStringGetDatum(stmt->tablespacename));
 	scandesc = table_beginscan_catalog(rel, 1, entry);
-	tup = heap_getnext(scandesc, ForwardScanDirection);
+	tup = table_scan_getnext(scandesc, ForwardScanDirection);
 	if (!HeapTupleIsValid(tup))
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
@@ -1528,7 +1528,7 @@ check_tablespace(const char *tablespacename)
 				BTEqualStrategyNumber, F_NAMEEQ,
 				CStringGetDatum(tablespacename));
 	scandesc = table_beginscan_catalog(rel, 1, entry);
-	tuple = heap_getnext(scandesc, ForwardScanDirection);
+	tuple = table_scan_getnext(scandesc, ForwardScanDirection);
 
 	/* If nothing matches then the tablespace doesn't exist */
 	if (HeapTupleIsValid(tuple))
@@ -1904,7 +1904,7 @@ get_tablespace_oid(const char *tablespacename, bool missing_ok)
 				BTEqualStrategyNumber, F_NAMEEQ,
 				CStringGetDatum(tablespacename));
 	scandesc = table_beginscan_catalog(rel, 1, entry);
-	tuple = heap_getnext(scandesc, ForwardScanDirection);
+	tuple = table_scan_getnext(scandesc, ForwardScanDirection);
 
 	/* If nothing matches then the tablespace doesn't exist */
 	if (HeapTupleIsValid(tuple))
@@ -1950,7 +1950,7 @@ get_tablespace_name(Oid spc_oid)
 				BTEqualStrategyNumber, F_OIDEQ,
 				ObjectIdGetDatum(spc_oid));
 	scandesc = table_beginscan_catalog(rel, 1, entry);
-	tuple = heap_getnext(scandesc, ForwardScanDirection);
+	tuple = table_scan_getnext(scandesc, ForwardScanDirection);
 
 	/* We assume that there can be at most one matching tuple */
 	if (HeapTupleIsValid(tuple))

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1114,7 +1114,7 @@ get_all_vacuum_rels(int options)
 	pgclass = table_open(RelationRelationId, AccessShareLock);
 	scan = table_beginscan_catalog(pgclass, 0, NULL);
 
-	while ((tuple = heap_getnext(scan, ForwardScanDirection)) != NULL)
+	while ((tuple = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 	{
 		Form_pg_class classForm = (Form_pg_class) GETSTRUCT(tuple);
 		MemoryContext oldcontext;
@@ -1724,7 +1724,7 @@ vac_update_relstats(Relation relation,
 
 	/* If anything changed, write out the tuple. */
 	if (dirty)
-		heap_inplace_update(rd, ctup);
+		inplace_table_tuple_update(rd, ctup);
 
 	table_close(rd, RowExclusiveLock);
 }
@@ -1979,7 +1979,7 @@ vac_update_datfrozenxid(void)
 		* https://github.com/greenplum-db/gpdb/commit/373e676de819fc0cdadfb59d35d9279abe3d11d9 
 		*/
 
-		heap_inplace_update(relation, tuple);
+		inplace_table_tuple_update(relation, tuple);
 #ifdef FAULT_INJECTOR
 		FaultInjector_InjectFaultIfSet(
 			"vacuum_update_dat_frozen_xid", DDLNotSpecified,
@@ -2062,7 +2062,7 @@ vac_truncate_clog(TransactionId frozenXID,
 
 	scan = table_beginscan_catalog(relation, 0, NULL);
 
-	while ((tuple = heap_getnext(scan, ForwardScanDirection)) != NULL)
+	while ((tuple = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 	{
 		volatile FormData_pg_database *dbform = (Form_pg_database) GETSTRUCT(tuple);
 		TransactionId datfrozenxid = dbform->datfrozenxid;
@@ -3216,7 +3216,7 @@ vac_update_relstats_from_list(VacuumStatsContext *stats_context)
 			{
 				aorel = table_open(AppendOnlyRelationId, RowExclusiveLock);
 				aoform->segfilecount = ao_segfile_count;
-				heap_inplace_update(aorel, aotup);
+				inplace_table_tuple_update(aorel, aotup);
 				table_close(aorel, RowExclusiveLock);
 			}
 			ReleaseSysCache(aotup);

--- a/src/backend/executor/execReplication.c
+++ b/src/backend/executor/execReplication.c
@@ -440,7 +440,7 @@ ExecSimpleRelationInsert(ResultRelInfo *resultRelInfo,
 			ExecPartitionCheck(resultRelInfo, slot, estate, true);
 
 		/* OK, store the tuple and create index entries for it */
-		simple_table_tuple_insert(resultRelInfo->ri_RelationDesc, slot);
+		simple_tuple_slot_insert(resultRelInfo->ri_RelationDesc, slot);
 
 		if (resultRelInfo->ri_NumIndices > 0)
 			recheckIndexes = ExecInsertIndexTuples(resultRelInfo,
@@ -507,7 +507,7 @@ ExecSimpleRelationUpdate(ResultRelInfo *resultRelInfo,
 		if (rel->rd_rel->relispartition)
 			ExecPartitionCheck(resultRelInfo, slot, estate, true);
 
-		simple_table_tuple_update(rel, tid, slot, estate->es_snapshot,
+		simple_tuple_slot_update(rel, tid, slot, estate->es_snapshot,
 								  &update_indexes);
 
 		if (resultRelInfo->ri_NumIndices > 0 && update_indexes)
@@ -553,7 +553,7 @@ ExecSimpleRelationDelete(ResultRelInfo *resultRelInfo,
 	if (!skip_tuple)
 	{
 		/* OK, delete the tuple */
-		simple_table_tuple_delete(rel, tid, estate->es_snapshot);
+		simple_tuple_slot_delete(rel, tid, estate->es_snapshot);
 
 		/* AFTER ROW DELETE Triggers */
 		ExecARDeleteTriggers(estate, resultRelInfo,

--- a/src/backend/postmaster/autovacuum.c
+++ b/src/backend/postmaster/autovacuum.c
@@ -1997,7 +1997,7 @@ get_database_list(void)
 	rel = table_open(DatabaseRelationId, AccessShareLock);
 	scan = table_beginscan_catalog(rel, 0, NULL);
 
-	while (HeapTupleIsValid(tup = heap_getnext(scan, ForwardScanDirection)))
+	while (HeapTupleIsValid(tup = table_scan_getnext(scan, ForwardScanDirection)))
 	{
 		Form_pg_database pgdatabase = (Form_pg_database) GETSTRUCT(tup);
 		avw_dbase  *avdb;
@@ -2161,7 +2161,7 @@ do_autovacuum(void)
 	 * On the first pass, we collect main tables to vacuum, and also the main
 	 * table relid to TOAST relid mapping.
 	 */
-	while ((tuple = heap_getnext(relScan, ForwardScanDirection)) != NULL)
+	while ((tuple = table_scan_getnext(relScan, ForwardScanDirection)) != NULL)
 	{
 		Form_pg_class classForm = (Form_pg_class) GETSTRUCT(tuple);
 		PgStat_StatTabEntry *tabentry;
@@ -2264,7 +2264,7 @@ do_autovacuum(void)
 				CharGetDatum(RELKIND_TOASTVALUE));
 
 	relScan = table_beginscan_catalog(classRel, 1, &key);
-	while ((tuple = heap_getnext(relScan, ForwardScanDirection)) != NULL)
+	while ((tuple = table_scan_getnext(relScan, ForwardScanDirection)) != NULL)
 	{
 		Form_pg_class classForm = (Form_pg_class) GETSTRUCT(tuple);
 		PgStat_StatTabEntry *tabentry;

--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -1349,7 +1349,7 @@ pgstat_collect_oids(Oid catalogid, AttrNumber anum_oid)
 	rel = table_open(catalogid, AccessShareLock);
 	snapshot = RegisterSnapshot(GetLatestSnapshot());
 	scan = table_beginscan(rel, snapshot, 0, NULL);
-	while ((tup = heap_getnext(scan, ForwardScanDirection)) != NULL)
+	while ((tup = table_scan_getnext(scan, ForwardScanDirection)) != NULL)
 	{
 		Oid			thisoid;
 		bool		isnull;

--- a/src/backend/replication/logical/launcher.c
+++ b/src/backend/replication/logical/launcher.c
@@ -113,7 +113,7 @@ get_subscription_list(void)
 	rel = table_open(SubscriptionRelationId, AccessShareLock);
 	scan = table_beginscan_catalog(rel, 0, NULL);
 
-	while (HeapTupleIsValid(tup = heap_getnext(scan, ForwardScanDirection)))
+	while (HeapTupleIsValid(tup = table_scan_getnext(scan, ForwardScanDirection)))
 	{
 		Form_pg_subscription subform = (Form_pg_subscription) GETSTRUCT(tup);
 		Subscription *sub;

--- a/src/backend/task/job_metadata.c
+++ b/src/backend/task/job_metadata.c
@@ -335,7 +335,7 @@ UnscheduleCronJob(const char *jobname, const char *username, Oid taskid, bool mi
 
 	EnsureDeletePermission(pg_task, heapTuple);
 
-	simple_heap_delete(pg_task, &heapTuple->t_self);
+	simple_table_tuple_delete(pg_task, &heapTuple->t_self);
 
 	systable_endscan(scanDescriptor);
 	table_close(pg_task, RowExclusiveLock);

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -1716,7 +1716,7 @@ ThereIsAtLeastOneRole(void)
 	pg_authid_rel = table_open(AuthIdRelationId, AccessShareLock);
 
 	scan = table_beginscan_catalog(pg_authid_rel, 0, NULL);
-	result = (heap_getnext(scan, ForwardScanDirection) != NULL);
+	result = (table_scan_getnext(scan, ForwardScanDirection) != NULL);
 
 	table_endscan(scan);
 	table_close(pg_authid_rel, AccessShareLock);

--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -2127,18 +2127,48 @@ table_scan_sample_next_tuple(TableScanDesc scan,
 														   slot);
 }
 
+/* ----------------------------------------------------------------------------
+ * Special access method routinue for catalog
+ * ----------------------------------------------------------------------------
+ */
+typedef struct CatalogAmHookRoutine
+{
+	HeapTuple (*getnext) (TableScanDesc scan, ScanDirection direction);
+	void (*frozen_insert) (Relation relation, HeapTuple tuple);
+	void (*inplace_update) (Relation relation, HeapTuple tuple);
+	void (*simple_insert) (Relation rel, HeapTuple tuple);
+	void (*simple_update) (Relation rel, ItemPointer otid, HeapTuple tuple);
+} CatalogAmHookRoutine;
+
+extern PGDLLIMPORT CatalogAmHookRoutine* catam_hook_routinue;
+
+/* ----------------------------------------------------------------------------
+ * Functions for special catalog access.
+ * ----------------------------------------------------------------------------
+ */
+
+extern HeapTuple table_scan_getnext(TableScanDesc scan,
+									ScanDirection direction);
+extern void frozen_table_tuple_insert(Relation relation, HeapTuple tuple);
+extern void inplace_table_tuple_update(Relation relation, HeapTuple tuple);
+
 
 /* ----------------------------------------------------------------------------
  * Functions to make modifications a bit simpler.
  * ----------------------------------------------------------------------------
  */
 
-extern void simple_table_tuple_insert(Relation rel, TupleTableSlot *slot);
-extern void simple_table_tuple_delete(Relation rel, ItemPointer tid,
-									  Snapshot snapshot);
+extern void simple_table_tuple_insert(Relation rel, HeapTuple tuple);
+extern void simple_table_tuple_delete(Relation rel, ItemPointer tid);
 extern void simple_table_tuple_update(Relation rel, ItemPointer otid,
-									  TupleTableSlot *slot, Snapshot snapshot,
-									  bool *update_indexes);
+									  HeapTuple tuple);
+
+extern void simple_tuple_slot_insert(Relation rel, TupleTableSlot *slot);
+extern void simple_tuple_slot_delete(Relation rel, ItemPointer tid,
+									 Snapshot snapshot);
+extern void simple_tuple_slot_update(Relation rel, ItemPointer otid,
+									 TupleTableSlot *slot, Snapshot snapshot,
+									 bool *update_indexes);
 
 
 /* ----------------------------------------------------------------------------


### PR DESCRIPTION
### Change logs

CloudBerry does not assume that the catalog use heap. Our approch uses
tableam interfaces instead of heap function calls.

These heap functions currently widely used within the catalog include:
heap_getnext, simple_heap_insert, simple_heap_delete,
simple_heap_update, frozen_heap_insert, and heap_inplace_update.

In order to replace these functions, we introduce necessary new simple
tableam interfaces: scan_getnext, tuple_insert_direct,
tuple_insert_frozen, tuple_update_direct, tuple_inplace_update.

All access methods that can used for catalog must implement these new
interfaces.

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to @cloudberrydb/dev team for review and approval when your PR is ready🥳
