### PR TITLE
Fix wrong results of Left Anti Semi (Not-In) Join

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -1455,7 +1455,7 @@ is_exprs_nullable_internal(Node *exprs, List *nonnullable_vars)
  *		select c1 from t1 where c1 NOT IN (select c2 from t2);
  *						(to)
  *		select c1 from t1 left anti semi join (select 0 as zero, c2 from t2) foo
- *						  ON (c1 = c2) IS NOT FALSE where zero is NULL;
+ *						  ON (c1 != c2) IS NOT FALSE where zero is NULL;
  *
  * The pseudoconstant column zero is needed to correctly pipe in the NULLs
  * from the subselect upstream.

--- a/src/test/regress/expected/notin.out
+++ b/src/test/regress/expected/notin.out
@@ -1436,6 +1436,71 @@ select * from t1_12930 where (a, b) not in (select a, b from t2_12930) and b is 
 ---+---
 (0 rows)
 
+--
+-- Test left anti semi (not-in) join
+-- With is null expression inside an OR expression.
+--
+begin;
+create table t1_lasj(c1 int) distributed by (c1);
+create table t2_lasj_has_null(c1n int) distributed by (c1n);
+insert into t1_lasj values (generate_series (1,10));
+insert into t2_lasj_has_null values (1), (2), (3), (null), (5), (6), (7);
+analyze t1_lasj;
+analyze t2_lasj_has_null;
+-- null test
+select c1 from t1_lasj where c1 not in (select c1n from t2_lasj_has_null where c1n is null) and c1 is not null;
+ c1 
+----
+(0 rows)
+
+-- null test under OR expression
+select c1 from t1_lasj where c1 not in (select c1n from t2_lasj_has_null where c1n is null or c1n > 0) and c1 is not null;
+ c1 
+----
+(0 rows)
+
+select c1 from t1_lasj where c1 not in (select c1n from t2_lasj_has_null where c1n > 0 or c1n is null) and c1 is not null;
+ c1 
+----
+(0 rows)
+
+select c1 from t1_lasj where c1 not in (select c1n from t2_lasj_has_null where (c1n > 1) or (c1n > 0 or c1n is null));
+ c1 
+----
+(0 rows)
+
+select c1 from t1_lasj where c1 not in (select c1n from t2_lasj_has_null where c1n is null or c1n is null and c1n > 1) and c1 is not null;
+ c1 
+----
+(0 rows)
+
+select c1 from t1_lasj where c1 not in (select c1n from t2_lasj_has_null where c1n is null or c1n is null or c1n > 1) and c1 is not null;
+ c1 
+----
+(0 rows)
+
+select c1 from t1_lasj where c1 not in (select c1n from t2_lasj_has_null where c1n is null or c1n is null) and c1 is not null;
+ c1 
+----
+(0 rows)
+
+-- null test under recursive OR expression
+select c1 from t1_lasj where c1 not in (select c1n from t2_lasj_has_null where (c1n != 0 and c1n > 1) or (c1n > 0 or c1n is null)) and c1 is not null;
+ c1 
+----
+(0 rows)
+
+select c1 from t1_lasj where c1 not in (select c1n from t2_lasj_has_null where c1n is null or c1n is null or true) and c1 is not null;
+ c1 
+----
+(0 rows)
+
+select c1 from t1_lasj where c1 not in (select c1n from t2_lasj_has_null where 2 > 1 or c1n is null or c1n is null or true) and c1 is not null;
+ c1 
+----
+(0 rows)
+
+abort;
 reset search_path;
 drop schema notin cascade;
 NOTICE:  drop cascades to 18 other objects

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -1480,6 +1480,71 @@ select * from t1_12930 where (a, b) not in (select a, b from t2_12930) and b is 
 ---+---
 (0 rows)
 
+--
+-- Test left anti semi (not-in) join
+-- With is null expression inside an OR expression.
+--
+begin;
+create table t1_lasj(c1 int) distributed by (c1);
+create table t2_lasj_has_null(c1n int) distributed by (c1n);
+insert into t1_lasj values (generate_series (1,10));
+insert into t2_lasj_has_null values (1), (2), (3), (null), (5), (6), (7);
+analyze t1_lasj;
+analyze t2_lasj_has_null;
+-- null test
+select c1 from t1_lasj where c1 not in (select c1n from t2_lasj_has_null where c1n is null) and c1 is not null;
+ c1 
+----
+(0 rows)
+
+-- null test under OR expression
+select c1 from t1_lasj where c1 not in (select c1n from t2_lasj_has_null where c1n is null or c1n > 0) and c1 is not null;
+ c1 
+----
+(0 rows)
+
+select c1 from t1_lasj where c1 not in (select c1n from t2_lasj_has_null where c1n > 0 or c1n is null) and c1 is not null;
+ c1 
+----
+(0 rows)
+
+select c1 from t1_lasj where c1 not in (select c1n from t2_lasj_has_null where (c1n > 1) or (c1n > 0 or c1n is null));
+ c1 
+----
+(0 rows)
+
+select c1 from t1_lasj where c1 not in (select c1n from t2_lasj_has_null where c1n is null or c1n is null and c1n > 1) and c1 is not null;
+ c1 
+----
+(0 rows)
+
+select c1 from t1_lasj where c1 not in (select c1n from t2_lasj_has_null where c1n is null or c1n is null or c1n > 1) and c1 is not null;
+ c1 
+----
+(0 rows)
+
+select c1 from t1_lasj where c1 not in (select c1n from t2_lasj_has_null where c1n is null or c1n is null) and c1 is not null;
+ c1 
+----
+(0 rows)
+
+-- null test under recursive OR expression
+select c1 from t1_lasj where c1 not in (select c1n from t2_lasj_has_null where (c1n != 0 and c1n > 1) or (c1n > 0 or c1n is null)) and c1 is not null;
+ c1 
+----
+(0 rows)
+
+select c1 from t1_lasj where c1 not in (select c1n from t2_lasj_has_null where c1n is null or c1n is null or true) and c1 is not null;
+ c1 
+----
+(0 rows)
+
+select c1 from t1_lasj where c1 not in (select c1n from t2_lasj_has_null where 2 > 1 or c1n is null or c1n is null or true) and c1 is not null;
+ c1 
+----
+(0 rows)
+
+abort;
 reset search_path;
 drop schema notin cascade;
 NOTICE:  drop cascades to 18 other objects


### PR DESCRIPTION
**This pr has 2 commits, please review by commits.**

See more details and discussion in https://github.com/greenplum-db/gpdb/pull/15663, https://github.com/greenplum-db/gpdb/issues/15662.

Most codes are same with some refinement & conflicts resolved for CBDB. 

[Fix wrong results of Left Anti Semi (Not-In) Join](https://github.com/cloudberrydb/cloudberrydb/commit/3dad049778929463c661ac56e13a50a4c12a3217)

CBDB will try to convert a NOT IN sql into a Left Anti Semi (Not-In) Join
by using cdb_find_nonnullable_vars_walker() to find if there might be nullable
values from inner or outer side.

If there is  NullTest, expression_tree_walker will iterate the tree using
(NullTest*)Node->arg.
Example:
```sql
select c1 from t1_lasj where c1 not in (
	select c1n from t2_lasj_has_null where c1n is null or c1n is null)
	and c1 is not null;
```
Expression c1n is null would be like:
NullTest [nulltesttype=IS_NULL argisrow=false location=102]
	[arg] Var [varno=1 varattno=1 vartype=23 varnoold=1 varoattno=1]

Recursive cdb_find_nonnullable_vars_walker will first check the node->arg Var and
insert into nonNullableVars.
That's incorrect for NullTest type IS_NULL.
We should consifer the NullTest under OR expression and recursive OR expression.
Add a field nullableVars to indentify the vars might be nullable, and must be
eliminated from nonNullableVars finally.
This is more strict, but ensure right results at least.


[Correct comments in convert_IN_to_antijoin()](https://github.com/cloudberrydb/cloudberrydb/commit/e0bcf2028888c5a93b25eaf80045220fd246ba50) 

Incorrect example comments:
The transformation is to rewrite a query of the form:
```sql
	select c1 from t1 where c1 NOT IN (select c2 from t2);
			(to)
	select c1 from t1 left anti semi join (select 0 as zero, c2 from t2) foo
		ON (c1 = c2) IS NOT FALSE where zero is NULL;
```
Correct it to:
The transformation is to rewrite a query of the form:
```sql
	select c1 from t1 where c1 NOT IN (select c2 from t2);
			(to)
	select c1 from t1 left anti semi join (select 0 as zero, c2 from t2) foo
		ON (c1 != c2) IS NOT FALSE where zero is NULL;
```
SQL NOT IN should be converted to Left Anti Semi (not-in) Join
with join condition c1 != c2.

Any non-null values from t1 don't match values from t2 shoule be kept and
IS NOT FALSE will return TRUE.

GDB checks after function make_lasj_quals()
join_expr->quals:
```shell
BoolExpr [boolop=NOT_EXPR]
        OpExpr [opno=518 opfuncid=144 opresulttype=16 opretset=false]
                Var [varno=1 varattno=1 vartype=23 varnoold=1 varoattno=1]
                Var [varno=2 varattno=1 vartype=23 varnoold=2 varoattno=1]
```

And oid 518 is a '<>' operator in pg_operator.
```sql
select oprname from pg_operator where oid = 518;
-[ RECORD 1 ]
oprname | <>
```



<!--Thank you for contributing!-->

<!--In case of an existing issue or discussions, please reference it-->
closes: #50 
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to @cloudberrydb/dev team for review and approval when your PR is ready🥳
