### PR TITLE
FIX: constraint check exception with snapshot memory leak in AO/AOCS

### DIFF
--- a/src/backend/access/appendonly/appendonly_visimap_store.c
+++ b/src/backend/access/appendonly/appendonly_visimap_store.c
@@ -43,7 +43,6 @@ AppendOnlyVisimapStore_Finish(AppendOnlyVisimapStore *visiMapStore,
 		visiMapStore->scanKeys = NULL;
 	}
 
-	UnregisterSnapshot(visiMapStore->snapshot);
 	index_close(visiMapStore->visimapIndex, lockmode);
 	table_close(visiMapStore->visimapRelation, lockmode);
 }
@@ -71,7 +70,7 @@ AppendOnlyVisimapStore_Init(AppendOnlyVisimapStore *visiMapStore,
 	Assert(OidIsValid(visimapRelid));
 	Assert(OidIsValid(visimapIdxid));
 
-	visiMapStore->snapshot = RegisterSnapshot(snapshot);
+	visiMapStore->snapshot = snapshot;
 	visiMapStore->memoryContext = memoryContext;
 
 	visiMapStore->visimapRelation = table_open(visimapRelid, lockmode);


### PR DESCRIPTION
<!--Thank you for contributing!-->

<!--In case of an existing issue or discussions, please reference it-->
closes: #93
<!--Remove this section if no corresponding issue.-->

---
### Change logs

This bug comes from AppendOnlyVisimapStore_Init calling RegisterSnapshot in appendonly_fetch_init, which creates a deep copy of the current snapshot. Therefore, when a constraint is violated(see function check_exclusion_or_unique_constraint in detail), EROOR will be performed directly, but UnregisterSnapshot in AppendOnlyVisimap_Finish is not called. Therefore, an Asset error will occur when the resource is finally recycled.

In order to solve this problem, we directly delete the RegisterSnapshot in AppendOnlyVisimapStore_Init which is useless and at the same time delete the UnregisterSnapshot.


### Why are the changes needed?

FIX: constraint check exception with snapshot memory leak in AO/AOCS


### Does this PR introduce any user-facing change?

No

### How was this patch tested?

No need

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [x] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [x] Sign the Contributor License Agreement as prompted for your first-time contribution.
- [x] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [x] Document changes.
- [x] Add tests for the change
- [x] Pass `make installcheck`
- [x] Pass `make -C src/test installcheck-cbdb-parallel`
- [x] Feel free to @cloudberrydb/dev team for review and approval when your PR is ready🥳
