### PR TITLE
Fix: warehouse is not supported without unionstore

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -261,7 +261,12 @@ readGpSegConfigFromCatalog(int *total_dbs)
 		attr = heap_getattr(gp_seg_config_tuple, Anum_gp_segment_configuration_warehouseid, RelationGetDescr(gp_seg_config_rel), &isNull);
 		Assert(!isNull);
 		warehouseid = DatumGetObjectId(attr);
-		if (OidIsValid(warehouseid) && warehouseid != GetCurrentWarehouseId())
+
+		/* content */
+		attr = heap_getattr(gp_seg_config_tuple, Anum_gp_segment_configuration_content, RelationGetDescr(gp_seg_config_rel), &isNull);
+		Assert(!isNull);
+
+		if (warehouseid != GetCurrentWarehouseId() && (OidIsValid(warehouseid) || DatumGetInt16(attr) != MASTER_CONTENT_ID))
 			continue;
 
 		config = &configs[idx];

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -266,69 +266,69 @@ readGpSegConfigFromCatalog(int *total_dbs)
 		attr = heap_getattr(gp_seg_config_tuple, Anum_gp_segment_configuration_content, RelationGetDescr(gp_seg_config_rel), &isNull);
 		Assert(!isNull);
 
-		if (warehouseid != GetCurrentWarehouseId() && (OidIsValid(warehouseid) || DatumGetInt16(attr) != MASTER_CONTENT_ID))
-			continue;
-
-		config = &configs[idx];
-
-		/* dbid */
-		attr = heap_getattr(gp_seg_config_tuple, Anum_gp_segment_configuration_dbid, RelationGetDescr(gp_seg_config_rel), &isNull);
-		Assert(!isNull);
-		config->dbid = DatumGetInt16(attr);
-
-		/* content */
-		attr = heap_getattr(gp_seg_config_tuple, Anum_gp_segment_configuration_content, RelationGetDescr(gp_seg_config_rel), &isNull);
-		Assert(!isNull);
-		config->segindex= DatumGetInt16(attr);
-
-		/* role */
-		attr = heap_getattr(gp_seg_config_tuple, Anum_gp_segment_configuration_role, RelationGetDescr(gp_seg_config_rel), &isNull);
-		Assert(!isNull);
-		config->role = DatumGetChar(attr);
-
-		/* preferred-role */
-		attr = heap_getattr(gp_seg_config_tuple, Anum_gp_segment_configuration_preferred_role, RelationGetDescr(gp_seg_config_rel), &isNull);
-		Assert(!isNull);
-		config->preferred_role = DatumGetChar(attr);
-
-		/* mode */
-		attr = heap_getattr(gp_seg_config_tuple, Anum_gp_segment_configuration_mode, RelationGetDescr(gp_seg_config_rel), &isNull);
-		Assert(!isNull);
-		config->mode = DatumGetChar(attr);
-
-		/* status */
-		attr = heap_getattr(gp_seg_config_tuple, Anum_gp_segment_configuration_status, RelationGetDescr(gp_seg_config_rel), &isNull);
-		Assert(!isNull);
-		config->status = DatumGetChar(attr);
-
-		/* hostname */
-		attr = heap_getattr(gp_seg_config_tuple, Anum_gp_segment_configuration_hostname, RelationGetDescr(gp_seg_config_rel), &isNull);
-		Assert(!isNull);
-		config->hostname = TextDatumGetCString(attr);
-
-		/* address */
-		attr = heap_getattr(gp_seg_config_tuple, Anum_gp_segment_configuration_address, RelationGetDescr(gp_seg_config_rel), &isNull);
-		Assert(!isNull);
-		config->address = TextDatumGetCString(attr);
-
-		/* port */
-		attr = heap_getattr(gp_seg_config_tuple, Anum_gp_segment_configuration_port, RelationGetDescr(gp_seg_config_rel), &isNull);
-		Assert(!isNull);
-		config->port = DatumGetInt32(attr);
-
-		/* datadir is not dumped*/
-
-		idx++;
-
-		/*
-		 * Expand CdbComponentDatabaseInfo array if we've used up
-		 * currently allocated space
-		 */
-		if (idx >= array_size)
+		if (warehouseid == GetCurrentWarehouseId() || DatumGetInt16(attr) == MASTER_CONTENT_ID)
 		{
-			array_size = array_size * 2;
-			configs = (GpSegConfigEntry *)
-				repalloc(configs, sizeof(GpSegConfigEntry) * array_size);
+			config = &configs[idx];
+
+			/* dbid */
+			attr = heap_getattr(gp_seg_config_tuple, Anum_gp_segment_configuration_dbid, RelationGetDescr(gp_seg_config_rel), &isNull);
+			Assert(!isNull);
+			config->dbid = DatumGetInt16(attr);
+
+			/* content */
+			attr = heap_getattr(gp_seg_config_tuple, Anum_gp_segment_configuration_content, RelationGetDescr(gp_seg_config_rel), &isNull);
+			Assert(!isNull);
+			config->segindex= DatumGetInt16(attr);
+
+			/* role */
+			attr = heap_getattr(gp_seg_config_tuple, Anum_gp_segment_configuration_role, RelationGetDescr(gp_seg_config_rel), &isNull);
+			Assert(!isNull);
+			config->role = DatumGetChar(attr);
+
+			/* preferred-role */
+			attr = heap_getattr(gp_seg_config_tuple, Anum_gp_segment_configuration_preferred_role, RelationGetDescr(gp_seg_config_rel), &isNull);
+			Assert(!isNull);
+			config->preferred_role = DatumGetChar(attr);
+
+			/* mode */
+			attr = heap_getattr(gp_seg_config_tuple, Anum_gp_segment_configuration_mode, RelationGetDescr(gp_seg_config_rel), &isNull);
+			Assert(!isNull);
+			config->mode = DatumGetChar(attr);
+
+			/* status */
+			attr = heap_getattr(gp_seg_config_tuple, Anum_gp_segment_configuration_status, RelationGetDescr(gp_seg_config_rel), &isNull);
+			Assert(!isNull);
+			config->status = DatumGetChar(attr);
+
+			/* hostname */
+			attr = heap_getattr(gp_seg_config_tuple, Anum_gp_segment_configuration_hostname, RelationGetDescr(gp_seg_config_rel), &isNull);
+			Assert(!isNull);
+			config->hostname = TextDatumGetCString(attr);
+
+			/* address */
+			attr = heap_getattr(gp_seg_config_tuple, Anum_gp_segment_configuration_address, RelationGetDescr(gp_seg_config_rel), &isNull);
+			Assert(!isNull);
+			config->address = TextDatumGetCString(attr);
+
+			/* port */
+			attr = heap_getattr(gp_seg_config_tuple, Anum_gp_segment_configuration_port, RelationGetDescr(gp_seg_config_rel), &isNull);
+			Assert(!isNull);
+			config->port = DatumGetInt32(attr);
+
+			/* datadir is not dumped*/
+
+			idx++;
+
+			/*
+			* Expand CdbComponentDatabaseInfo array if we've used up
+			* currently allocated space
+			*/
+			if (idx >= array_size)
+			{
+				array_size = array_size * 2;
+				configs = (GpSegConfigEntry *)
+					repalloc(configs, sizeof(GpSegConfigEntry) * array_size);
+			}
 		}
 	}
 

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1788,7 +1788,14 @@ ProcessUtilitySlow(ParseState *pstate,
 
 			case T_DropTaskStmt:
 				address = DropTask(pstate, (DropTaskStmt *) parsetree);
-				break;				
+				break;
+
+			case T_CreateWarehouseStmt:
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("warehouse feature is not supported"),
+						 errhint("Create extension unionstore to enable the feature.")));
+				break;
 
 			case T_CreateExternalStmt:
 				{

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1791,10 +1791,10 @@ ProcessUtilitySlow(ParseState *pstate,
 				break;
 
 			case T_CreateWarehouseStmt:
+			case T_DropWarehouseStmt:
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("warehouse feature is not supported"),
-						 errhint("Create extension unionstore to enable the feature.")));
+						 errmsg("warehouse feature is not supported")));
 				break;
 
 			case T_CreateExternalStmt:


### PR DESCRIPTION
This commit mainly adds that the warehouse feature is not supported by default, but we can create the unionstore extension to enable the feature.

BTW, fix the bug when query from gp_segment_configuration table.

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to @cloudberrydb/dev team for review and approval when your PR is ready🥳
