### PR TITLE
Fix unstable tests reindextable_while_reindex_idx

### DIFF
--- a/src/test/isolation2/expected/reindex/reindextable_while_reindex_idx_ao_part_btree.out
+++ b/src/test/isolation2/expected/reindex/reindextable_while_reindex_idx_ao_part_btree.out
@@ -36,12 +36,22 @@ REINDEX
 3: insert into old_relfilenodes (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class') where relname like 'reindex_crtab_part_ao_btree%_idx' union all select gp_segment_id as dbid, relfilenode, oid, relname from pg_class where relname like 'reindex_crtab_part_ao_btree%_idx');
 INSERT 12
 -- Expect two distinct relfilenodes for one segment in old_relfilenodes table.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
- count | relname                                           
--------+---------------------------------------------------
- 1     | reindex_crtab_part_ao_btree_1_prt_p_one_id_idx    
- 2     | reindex_crtab_part_ao_btree_1_prt_de_fault_id_idx 
- 1     | reindex_crtab_part_ao_btree_id_idx                
+-- CBDB#26: This test actually assumes when txn1 commits, its lock is acquired by
+-- txn3, and txn2 is blocked by it. Normally this is the case, but when the system
+-- load is high (e.g., when parallel is enabled, or other processes stress the system),
+-- it could be the case that the scheduler pass the access exclusive lock acquired by
+-- txn1 to txn2 (not txn3) in L22-L23, invalidate the assumption, causing the test to fail.
+-- Here I workaround this by instead of relying on the only one expected file which
+-- cannot checks two behaviour, SQL statement is used to directly check the correctness
+-- of one column.
+-- See https://github.com/cloudberrydb/cloudberrydb/issues/26#issuecomment-1682097755
+-- for more details.
+3: select relname, relname = 'reindex_crtab_part_ao_btree_1_prt_p_one_id_idx' and res.cnt in (1, 2) as special_case_for_p_one_id_idx, case when relname = 'reindex_crtab_part_ao_btree_1_prt_p_one_id_idx' then -1 else res.cnt end as count from (select distinct count(distinct relfilenode) as cnt, relname from old_relfilenodes group by dbid, relname) as res;
+ relname                                           | special_case_for_p_one_id_idx | count 
+---------------------------------------------------+-------------------------------+-------
+ reindex_crtab_part_ao_btree_1_prt_p_one_id_idx    | t                             | -1    
+ reindex_crtab_part_ao_btree_1_prt_de_fault_id_idx | f                             | 2     
+ reindex_crtab_part_ao_btree_id_idx                | f                             | 1     
 (3 rows)
 3: COMMIT;
 COMMIT
@@ -52,12 +62,13 @@ REINDEX
 3: insert into old_relfilenodes (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class') where relname like 'reindex_crtab_part_ao_btree%_idx' union all select gp_segment_id as dbid, relfilenode, oid, relname from pg_class where relname like 'reindex_crtab_part_ao_btree%_idx');
 INSERT 12
 -- Expect three distinct relfilenodes per segment for "1_prt_de_fault" index.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
- count | relname                                           
--------+---------------------------------------------------
- 3     | reindex_crtab_part_ao_btree_1_prt_de_fault_id_idx 
- 2     | reindex_crtab_part_ao_btree_1_prt_p_one_id_idx    
- 1     | reindex_crtab_part_ao_btree_id_idx                
+-- CBDB#26: Same as L45.
+3: select relname, relname = 'reindex_crtab_part_ao_btree_1_prt_de_fault_id_idx' and res.cnt in (2, 3) as special_case_for_de_fault_id_idx, case when relname = 'reindex_crtab_part_ao_btree_1_prt_de_fault_id_idx' then -1 else res.cnt end as count from (select distinct count(distinct relfilenode) as cnt, relname from old_relfilenodes group by dbid, relname) as res;
+ relname                                           | special_case_for_de_fault_id_idx | count 
+---------------------------------------------------+----------------------------------+-------
+ reindex_crtab_part_ao_btree_1_prt_de_fault_id_idx | t                                | -1    
+ reindex_crtab_part_ao_btree_id_idx                | f                                | 1     
+ reindex_crtab_part_ao_btree_1_prt_p_one_id_idx    | f                                | 2     
 (3 rows)
 
 3: select count(*) from reindex_crtab_part_ao_btree where id = 998;

--- a/src/test/isolation2/expected/reindex/reindextable_while_reindex_idx_aoco_part_btree.out
+++ b/src/test/isolation2/expected/reindex/reindextable_while_reindex_idx_aoco_part_btree.out
@@ -35,12 +35,22 @@ REINDEX
 3: insert into old_relfilenodes (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class') where relname like 'reindex_crtab_part_aoco_btree%_idx' union all select gp_segment_id as dbid, relfilenode, oid, relname from pg_class where relname like 'reindex_crtab_part_aoco_btree%_idx');
 INSERT 12
 -- Expect two distinct relfilenodes for one segment in old_relfilenodes table.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
- count | relname                                             
--------+-----------------------------------------------------
- 2     | reindex_crtab_part_aoco_btree_1_prt_de_fault_id_idx 
- 1     | reindex_crtab_part_aoco_btree_1_prt_p_one_id_idx    
- 1     | reindex_crtab_part_aoco_btree_id_idx                
+-- CBDB#26: This test actually assumes when txn1 commits, its lock is acquired by
+-- txn3, and txn2 is blocked by it. Normally this is the case, but when the system
+-- load is high (e.g., when parallel is enabled, or other processes stress the system),
+-- it could be the case that the scheduler pass the access exclusive lock acquired by
+-- txn1 to txn2 (not txn3) in L22-L23, invalidate the assumption, causing the test to fail.
+-- Here I workaround this by instead of relying on the only one expected file which
+-- cannot checks two behaviour, SQL statement is used to directly check the correctness
+-- of one column.
+-- See https://github.com/cloudberrydb/cloudberrydb/issues/26#issuecomment-1682097755
+-- for more details.
+3: select relname, relname = 'reindex_crtab_part_aoco_btree_1_prt_p_one_id_idx' and res.cnt in (1, 2) as special_case_for_p_one_id_idx, case when relname = 'reindex_crtab_part_aoco_btree_1_prt_p_one_id_idx' then -1 else res.cnt end as count from (select distinct count(distinct relfilenode) as cnt, relname from old_relfilenodes group by dbid, relname) as res;
+ relname                                             | special_case_for_p_one_id_idx | count 
+-----------------------------------------------------+-------------------------------+-------
+ reindex_crtab_part_aoco_btree_1_prt_de_fault_id_idx | f                             | 2     
+ reindex_crtab_part_aoco_btree_id_idx                | f                             | 1     
+ reindex_crtab_part_aoco_btree_1_prt_p_one_id_idx    | t                             | -1    
 (3 rows)
 3: COMMIT;
 COMMIT
@@ -51,12 +61,13 @@ REINDEX
 3: insert into old_relfilenodes (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class') where relname like 'reindex_crtab_part_aoco_btree%_idx' union all select gp_segment_id as dbid, relfilenode, oid, relname from pg_class where relname like 'reindex_crtab_part_aoco_btree%_idx');
 INSERT 12
 -- Expect three distinct relfilenodes per segment for "1_prt_de_fault" index.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
- count | relname                                             
--------+-----------------------------------------------------
- 1     | reindex_crtab_part_aoco_btree_id_idx                
- 2     | reindex_crtab_part_aoco_btree_1_prt_p_one_id_idx    
- 3     | reindex_crtab_part_aoco_btree_1_prt_de_fault_id_idx 
+-- CBDB#26: Same as L45.
+3: select relname, relname = 'reindex_crtab_part_aoco_btree_1_prt_de_fault_id_idx' and res.cnt in (2, 3) as special_case_for_de_fault_id_idx, case when relname = 'reindex_crtab_part_aoco_btree_1_prt_de_fault_id_idx' then -1 else res.cnt end as count from (select distinct count(distinct relfilenode) as cnt, relname from old_relfilenodes group by dbid, relname) as res;
+ relname                                             | special_case_for_de_fault_id_idx | count 
+-----------------------------------------------------+----------------------------------+-------
+ reindex_crtab_part_aoco_btree_1_prt_de_fault_id_idx | t                                | -1    
+ reindex_crtab_part_aoco_btree_id_idx                | f                                | 1     
+ reindex_crtab_part_aoco_btree_1_prt_p_one_id_idx    | f                                | 2     
 (3 rows)
 
 3: select count(*) from reindex_crtab_part_aoco_btree where id = 998;

--- a/src/test/isolation2/expected/reindex/reindextable_while_reindex_idx_heap_part_btree.out
+++ b/src/test/isolation2/expected/reindex/reindextable_while_reindex_idx_heap_part_btree.out
@@ -35,12 +35,22 @@ REINDEX
 3: insert into old_relfilenodes (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class') where relname like 'reindex_crtab_part_heap_btree%_idx' union all select gp_segment_id as dbid, relfilenode, oid, relname from pg_class where relname like 'reindex_crtab_part_heap_btree%_idx');
 INSERT 12
 -- Expect two distinct relfilenodes for one segment in old_relfilenodes table.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
- count | relname                                             
--------+-----------------------------------------------------
- 1     | reindex_crtab_part_heap_btree_id_idx                
- 2     | reindex_crtab_part_heap_btree_1_prt_de_fault_id_idx 
- 1     | reindex_crtab_part_heap_btree_1_prt_p_one_id_idx    
+-- CBDB#26: This test actually assumes when txn1 commits, its lock is acquired by
+-- txn3, and txn2 is blocked by it. Normally this is the case, but when the system
+-- load is high (e.g., when parallel is enabled, or other processes stress the system),
+-- it could be the case that the scheduler pass the access exclusive lock acquired by
+-- txn1 to txn2 (not txn3) in L22-L23, invalidate the assumption, causing the test to fail.
+-- Here I workaround this by instead of relying on the only one expected file which
+-- cannot checks two behaviour, SQL statement is used to directly check the correctness
+-- of one column.
+-- See https://github.com/cloudberrydb/cloudberrydb/issues/26#issuecomment-1682097755
+-- for more details.
+3: select relname, relname = 'reindex_crtab_part_heap_btree_1_prt_p_one_id_idx' and res.cnt in (1, 2) as special_case_for_p_one_id_idx, case when relname = 'reindex_crtab_part_heap_btree_1_prt_p_one_id_idx' then -1 else res.cnt end as count from (select distinct count(distinct relfilenode) as cnt, relname from old_relfilenodes group by dbid, relname) as res;
+ relname                                             | special_case_for_p_one_id_idx | count 
+-----------------------------------------------------+-------------------------------+-------
+ reindex_crtab_part_heap_btree_1_prt_p_one_id_idx    | t                             | -1    
+ reindex_crtab_part_heap_btree_1_prt_de_fault_id_idx | f                             | 2     
+ reindex_crtab_part_heap_btree_id_idx                | f                             | 1     
 (3 rows)
 3: COMMIT;
 COMMIT
@@ -51,12 +61,13 @@ REINDEX
 3: insert into old_relfilenodes (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class') where relname like 'reindex_crtab_part_heap_btree%_idx' union all select gp_segment_id as dbid, relfilenode, oid, relname from pg_class where relname like 'reindex_crtab_part_heap_btree%_idx');
 INSERT 12
 -- Expect three distinct relfilenodes per segment for "1_prt_de_fault" index.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
- count | relname                                             
--------+-----------------------------------------------------
- 1     | reindex_crtab_part_heap_btree_id_idx                
- 3     | reindex_crtab_part_heap_btree_1_prt_de_fault_id_idx 
- 2     | reindex_crtab_part_heap_btree_1_prt_p_one_id_idx    
+-- CBDB#26: Same as L45.
+3: select relname, relname = 'reindex_crtab_part_heap_btree_1_prt_de_fault_id_idx' and res.cnt in (2, 3) as special_case_for_de_fault_id_idx, case when relname = 'reindex_crtab_part_heap_btree_1_prt_de_fault_id_idx' then -1 else res.cnt end as count from (select distinct count(distinct relfilenode) as cnt, relname from old_relfilenodes group by dbid, relname) as res;
+ relname                                             | special_case_for_de_fault_id_idx | count 
+-----------------------------------------------------+----------------------------------+-------
+ reindex_crtab_part_heap_btree_id_idx                | f                                | 1     
+ reindex_crtab_part_heap_btree_1_prt_p_one_id_idx    | f                                | 2     
+ reindex_crtab_part_heap_btree_1_prt_de_fault_id_idx | t                                | -1    
 (3 rows)
 
 3: select count(*) from reindex_crtab_part_heap_btree where id = 998;

--- a/src/test/isolation2/sql/reindex/reindextable_while_reindex_idx_aoco_part_btree.sql
+++ b/src/test/isolation2/sql/reindex/reindextable_while_reindex_idx_aoco_part_btree.sql
@@ -32,7 +32,23 @@ DELETE FROM reindex_crtab_part_aoco_btree  WHERE id < 128;
     select gp_segment_id as dbid, relfilenode, oid, relname from pg_class
     where relname like 'reindex_crtab_part_aoco_btree%_idx');
 -- Expect two distinct relfilenodes for one segment in old_relfilenodes table.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
+-- CBDB#26: This test actually assumes when txn1 commits, its lock is acquired by
+-- txn3, and txn2 is blocked by it. Normally this is the case, but when the system
+-- load is high (e.g., when parallel is enabled, or other processes stress the system),
+-- it could be the case that the scheduler pass the access exclusive lock acquired by
+-- txn1 to txn2 (not txn3) in L22-L23, invalidate the assumption, causing the test to fail.
+-- Here I workaround this by instead of relying on the only one expected file which
+-- cannot checks two behaviour, SQL statement is used to directly check the correctness
+-- of one column.
+-- See https://github.com/cloudberrydb/cloudberrydb/issues/26#issuecomment-1682097755
+-- for more details.
+3: select relname,
+          relname = 'reindex_crtab_part_aoco_btree_1_prt_p_one_id_idx' and res.cnt in (1, 2) as special_case_for_p_one_id_idx,
+          case
+              when relname = 'reindex_crtab_part_aoco_btree_1_prt_p_one_id_idx' then -1
+              else res.cnt
+          end as count
+   from (select distinct count(distinct relfilenode) as cnt, relname from old_relfilenodes group by dbid, relname) as res;
 3: COMMIT;
 -- After session 3 commits, session 2 could complete, the relfilenode it assigned to the
 -- "1_prt_de_fault" index is visible to session 3.
@@ -44,7 +60,14 @@ DELETE FROM reindex_crtab_part_aoco_btree  WHERE id < 128;
     select gp_segment_id as dbid, relfilenode, oid, relname from pg_class
     where relname like 'reindex_crtab_part_aoco_btree%_idx');
 -- Expect three distinct relfilenodes per segment for "1_prt_de_fault" index.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
+-- CBDB#26: Same as L45.
+3: select relname,
+          relname = 'reindex_crtab_part_aoco_btree_1_prt_de_fault_id_idx' and res.cnt in (2, 3) as special_case_for_de_fault_id_idx,
+          case
+              when relname = 'reindex_crtab_part_aoco_btree_1_prt_de_fault_id_idx' then -1
+              else res.cnt
+          end as count
+   from (select distinct count(distinct relfilenode) as cnt, relname from old_relfilenodes group by dbid, relname) as res;
 
 3: select count(*) from reindex_crtab_part_aoco_btree where id = 998;
 3: set enable_seqscan=false;

--- a/src/test/isolation2/sql/reindex/reindextable_while_reindex_idx_heap_part_btree.sql
+++ b/src/test/isolation2/sql/reindex/reindextable_while_reindex_idx_heap_part_btree.sql
@@ -32,7 +32,23 @@ DELETE FROM reindex_crtab_part_heap_btree  WHERE id < 128;
     select gp_segment_id as dbid, relfilenode, oid, relname from pg_class
     where relname like 'reindex_crtab_part_heap_btree%_idx');
 -- Expect two distinct relfilenodes for one segment in old_relfilenodes table.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
+-- CBDB#26: This test actually assumes when txn1 commits, its lock is acquired by
+-- txn3, and txn2 is blocked by it. Normally this is the case, but when the system
+-- load is high (e.g., when parallel is enabled, or other processes stress the system),
+-- it could be the case that the scheduler pass the access exclusive lock acquired by
+-- txn1 to txn2 (not txn3) in L22-L23, invalidate the assumption, causing the test to fail.
+-- Here I workaround this by instead of relying on the only one expected file which
+-- cannot checks two behaviour, SQL statement is used to directly check the correctness
+-- of one column.
+-- See https://github.com/cloudberrydb/cloudberrydb/issues/26#issuecomment-1682097755
+-- for more details.
+3: select relname,
+          relname = 'reindex_crtab_part_heap_btree_1_prt_p_one_id_idx' and res.cnt in (1, 2) as special_case_for_p_one_id_idx,
+          case
+              when relname = 'reindex_crtab_part_heap_btree_1_prt_p_one_id_idx' then -1
+              else res.cnt
+          end as count
+   from (select distinct count(distinct relfilenode) as cnt, relname from old_relfilenodes group by dbid, relname) as res;
 3: COMMIT;
 -- After session 3 commits, session 2 could complete, the relfilenode it assigned to the
 -- "1_prt_de_fault" index is visible to session 3.
@@ -44,7 +60,14 @@ DELETE FROM reindex_crtab_part_heap_btree  WHERE id < 128;
     select gp_segment_id as dbid, relfilenode, oid, relname from pg_class
     where relname like 'reindex_crtab_part_heap_btree%_idx');
 -- Expect three distinct relfilenodes per segment for "1_prt_de_fault" index.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
+-- CBDB#26: Same as L45.
+3: select relname,
+          relname = 'reindex_crtab_part_heap_btree_1_prt_de_fault_id_idx' and res.cnt in (2, 3) as special_case_for_de_fault_id_idx,
+          case
+              when relname = 'reindex_crtab_part_heap_btree_1_prt_de_fault_id_idx' then -1
+              else res.cnt
+          end as count
+    from (select distinct count(distinct relfilenode) as cnt, relname from old_relfilenodes group by dbid, relname) as res;
 
 3: select count(*) from reindex_crtab_part_heap_btree where id = 998;
 3: set enable_seqscan=false;


### PR DESCRIPTION
<!--Thank you for contributing!-->

<!--In case of an existing issue or discussions, please reference it-->
closes: #26 
<!--Remove this section if no corresponding issue.-->

---

### Change logs

Three unstable tests matching reindex/reindextable_while_reindex_idx_*_part_btree are fixed. They failed in the same way thus could be fixed in the same manner.

These tests actually assumes when txn1 commits, its lock is acquired by txn3, and txn2 is blocked by it. Normally this is the case, but when the system load is high (e.g., when parallel is enabled, or other processes stress the system), it could be the case that the scheduler pass the access exclusive lock acquired by txn1 to txn2 (not txn3) in L22-L23, invalidate the assumption, causing the test to fail. Here I workaround this by instead of relying on the only one expected file which cannot checks two behaviour, SQL statement is used to directly check the correctness of one column.

This problem is also found in the upstream, mainline GPDB.

---

Note that this is a initial fix of one out of three total problematic cases. I'll fixed others once this passed review.