### PR TITLE
Add extensible smgr slot for other storage format.

### DIFF
--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -157,7 +157,7 @@ RelationCreateStorage(RelFileNode rnode, char relpersistence, SMgrImpl smgr_whic
 	pending->relnode.isTempRelation = backend == TempRelBackendId;
 	pending->atCommit = false;	/* delete if abort */
 	pending->nestLevel = GetCurrentTransactionNestLevel();
-	pending->relnode.smgr_which = smgr_which;
+	pending->relnode.smgr_which = srel->smgr_which;
 	pending->next = pendingDeletes;
 	pendingDeletes = pending;
 
@@ -198,6 +198,11 @@ void
 RelationDropStorage(Relation rel)
 {
 	PendingRelDelete *pending;
+	SMgrRelation srel;
+
+	srel = smgropen(rel->rd_node, rel->rd_backend,
+				      RelationIsAppendOptimized(rel) ? SMGR_AO : SMGR_MD,
+				      rel);
 
 	/* Add the relation to the list of stuff to delete at commit */
 	pending = (PendingRelDelete *)
@@ -206,8 +211,7 @@ RelationDropStorage(Relation rel)
 	pending->relnode.isTempRelation = rel->rd_backend == TempRelBackendId;
 	pending->atCommit = true;	/* delete if commit */
 	pending->nestLevel = GetCurrentTransactionNestLevel();
-	pending->relnode.smgr_which =
-		RelationIsAppendOptimized(rel) ? SMGR_AO : SMGR_MD;
+	pending->relnode.smgr_which = srel->smgr_which;
 	pending->next = pendingDeletes;
 	pendingDeletes = pending;
 
@@ -221,6 +225,7 @@ RelationDropStorage(Relation rel)
 	 * for now I'll keep the logic simple.
 	 */
 
+	smgrclose(srel);
 	RelationCloseSmgr(rel);
 }
 

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -25,8 +25,10 @@
 
 typedef enum SMgrImplementation
 {
-	SMGR_MD = 0,
-	SMGR_AO = 1
+    SMGR_MD = 0,
+    SMGR_AO = 1,
+
+    SMGR_LAST_DEFAULT = SMGR_AO
 } SMgrImpl;
 
 struct f_smgr;
@@ -164,6 +166,7 @@ extern void smgrtruncate(SMgrRelation reln, ForkNumber *forknum,
 						 int nforks, BlockNumber *nblocks);
 extern void smgrimmedsync(SMgrRelation reln, ForkNumber forknum);
 extern void AtEOXact_SMgr(void);
+extern SMgrImpl add_smgr_kind(void);
 
 
 /*
@@ -183,4 +186,5 @@ extern PGDLLIMPORT file_truncate_hook_type file_truncate_hook;
 typedef void (*file_unlink_hook_type)(RelFileNodeBackend rnode);
 extern PGDLLIMPORT file_unlink_hook_type file_unlink_hook;
 
+extern f_smgr smgrsw[];
 #endif							/* SMGR_H */


### PR DESCRIPTION
This commit is mainly used to add extensible smgr slot for other extension storage format. When we create storage format extension, will add relevant smgr slot in smgrsw array. Morever,add smgropen and smgrclose in RelationDropStorage.

authored-by: Zhang Wenchao zwcpostgres@gmail.com

<!--Thank you for contributing!-->

<!--In case of an existing issue or discussions, please reference it-->
closes: #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to @cloudberrydb/dev team for review and approval when your PR is ready🥳
