### PR TITLE
Feature: lazy initialize orca optimizer

### DIFF
--- a/src/backend/utils/adt/gp_optimizer_functions.c
+++ b/src/backend/utils/adt/gp_optimizer_functions.c
@@ -15,6 +15,11 @@
 
 #include "funcapi.h"
 #include "utils/builtins.h"
+#include "optimizer/planner.h"
+
+#ifdef USE_ORCA
+extern void InitGPOPT();
+#endif
 
 extern Datum EnableXform(PG_FUNCTION_ARGS);
 
@@ -25,6 +30,16 @@ Datum
 enable_xform(PG_FUNCTION_ARGS)
 {
 #ifdef USE_ORCA
+	if (!optimizer_init) {
+		/* Initialize GPOPT */
+		OptimizerMemoryContext = AllocSetContextCreate(TopMemoryContext,
+													"GPORCA Top-level Memory Context",
+													ALLOCSET_DEFAULT_MINSIZE,
+													ALLOCSET_DEFAULT_INITSIZE,
+													ALLOCSET_DEFAULT_MAXSIZE);
+		InitGPOPT();
+		optimizer_init = true;
+	}
 	return EnableXform(fcinfo);
 #else
 	return CStringGetTextDatum("Server has been compiled without ORCA");
@@ -40,6 +55,16 @@ Datum
 disable_xform(PG_FUNCTION_ARGS)
 {
 #ifdef USE_ORCA
+	if (!optimizer_init) {
+		/* Initialize GPOPT */
+		OptimizerMemoryContext = AllocSetContextCreate(TopMemoryContext,
+													"GPORCA Top-level Memory Context",
+													ALLOCSET_DEFAULT_MINSIZE,
+													ALLOCSET_DEFAULT_INITSIZE,
+													ALLOCSET_DEFAULT_MAXSIZE);
+		InitGPOPT();
+		optimizer_init = true;
+	}
 	return DisableXform(fcinfo);
 #else
 	return CStringGetTextDatum("Server has been compiled without ORCA");

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -676,17 +676,7 @@ InitPostgres(const char *in_dbname, Oid dboid, const char *username,
 	/* Initialize memory protection */
 	GPMemoryProtect_Init();
 
-#ifdef USE_ORCA
-	/* Initialize GPOPT */
-	OptimizerMemoryContext = AllocSetContextCreate(TopMemoryContext,
-												   "GPORCA Top-level Memory Context",
-												   ALLOCSET_DEFAULT_MINSIZE,
-												   ALLOCSET_DEFAULT_INITSIZE,
-												   ALLOCSET_DEFAULT_MAXSIZE);
 
-	if (!bootstrap && Gp_role == GP_ROLE_DISPATCH)
-		InitGPOPT();
-#endif
 
 	/*
 	 * Initialize my entry in the shared-invalidation manager's array of

--- a/src/include/optimizer/planner.h
+++ b/src/include/optimizer/planner.h
@@ -60,4 +60,6 @@ extern Path *get_cheapest_fractional_path(RelOptInfo *rel,
 
 extern Expr *preprocess_phv_expression(PlannerInfo *root, Expr *expr);
 
+extern bool optimizer_init;
+
 #endif							/* PLANNER_H */


### PR DESCRIPTION
<!--Thank you for contributing!-->

<!--In case of an existing issue or discussions, please reference it-->
closes: #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

We lazy initialize the orca optimizer, because the InitGPOPT() will consume losts of memory. his may increase the number of connections to QD, thereby increasing tps. 

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [x] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [x] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [x] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [x] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [x] Document changes.
- [x] Add tests for the change
- [x] Pass `make installcheck`
- [x] Pass `make -C src/test installcheck-cbdb-parallel`
- [x] Feel free to @cloudberrydb/dev team for review and approval when your PR is ready🥳
