### PR TITLE
Fix portability issues on macOS with gcc-13

### DIFF
--- a/src/backend/utils/adt/matrix.c
+++ b/src/backend/utils/adt/matrix.c
@@ -176,7 +176,7 @@ matrix_add(PG_FUNCTION_ARGS)
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						 errmsg("matrix_add: non-conformable arrays")));
 		}
-		if (ARR_NULLBITMAP(m) || ARR_NULLBITMAP(n))
+		if (ARR_HASNULL(m) || ARR_HASNULL(n))
 			ereport(ERROR,
 					(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 					 errmsg("matrix_add: null array element not allowed in this context")));

--- a/src/fe_utils/log.c
+++ b/src/fe_utils/log.c
@@ -94,7 +94,7 @@ cbdb_log(cbdb_log_level level, const char* file, int line, const char* format, .
     gettimeofday(&tv, NULL);
     ptm = localtime(&tv.tv_sec);
     strftime(date, sizeof(date), "%Y-%m-%d %H:%M:%S", ptm);
-    snprintf(timestamp, MAX_TIMESTAMP_LENGTH, "%s.%06ld", date, tv.tv_usec);
+    snprintf(timestamp, MAX_TIMESTAMP_LENGTH, "%s.%06ld", date, (long) tv.tv_usec);
 
     // record timestamp, file name, and line num
     len = snprintf(NULL, 0, fmt, timestamp, s_level[level], file, line);

--- a/src/include/crypto/sm4.h
+++ b/src/include/crypto/sm4.h
@@ -12,15 +12,6 @@
 #define _SM4_H_
 #include "c.h"
 
-typedef signed char int8_t;
-typedef unsigned char uint8_t;
-typedef short int16_t;
-typedef unsigned short uint16_t;
-typedef int int32_t;
-typedef unsigned int uint32_t;
-typedef long int64_t;
-typedef unsigned long int uint64_t;
-
 # define SM4_ENCRYPT     1
 # define SM4_DECRYPT     0
 


### PR DESCRIPTION
### Change logs

This PR solves portability issues causing CBDB failed to compile on macOS using gcc-13:
- `matrix.c`: gcc-12 and newer enhanced `-Waddress` to warn more always-false bool expressions, which makes one line in `matrix.c` to be warned and GPDB is refused to compile using gcc-12 and newer toolchain.
- `log.c`: on MacOS, `timeval.tv_usec` is defined differently which needs to be casted in order to be printed by %ld.
- `sm4.h`: type definations conflict with the system header on various different platforms.

See: https://gcc.gnu.org/gcc-12/changes.html

### How was this patch tested?

Because we currently don't have a gcc-13 nor a macOS pipeline, automated testing is not possible. I manually tested this PR on Intel mac and Apple M2 mac, they all successfully build the binaries though special `configure` arguments are required. I've talked to releng team to write a script to make these steps easier.

Testing procedure:
1. `brew install gcc` and make sure your `gcc --version` is **_a real `gcc`_ not something aliased to clang**.
2. run `readmes/README.macOS.bash` to install all dependencies
3. `BREWPREFIX=$(brew --prefix); CXXFLAGS="-I $BREWPREFIX/Cellar/xerces-c/3.2.4_1/include" CFLAGS="-ggdb -Og -g3 -fno-omit-frame-pointer -I $BREWPREFIX/include -I $BREWPREFIX/Cellar/xerces-c/3.2.4_1/include"  LDFLAGS="-L $BREWPREFIX/Cellar/libevent/2.1.12_1/lib -L $BREWPREFIX/Cellar/xerces-c/3.2.4_1/lib -L $BREWPREFIX/opt/zstd/lib" ./configure --enable-debug --prefix=/home/gpadmin/install/cbdb`
4. `make -j12 install`

Maybe we should modify the `readmes/README.macOS.bash` to install the dependencies **and** `ln` all Cellar headers and libs to `$(brew --predix)/include` and `$(brew --predix)/lib` so that we don't need to specify any special paths in `-I` and `-L`.

## Caveat

> [!WARNING]
> **w/o a CI pipeline to guard against any changes that may break portability, CBDB could soon turns unportable again. Such thing has already happened to GPDB, their repo is entirely incompatible with gcc-13.** I suggest we should at least add a small build (not testing, just build) pipeline on _gcc-13 on macOS_, or *gcc-13 on Linux* at least.