### PR TITLE
Fix unportable scripts on macOS

### DIFF
--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -9,6 +9,7 @@ $(recurse)
 generate_greenplum_path_file:
 	mkdir -p $(DESTDIR)$(prefix)
 	unset LIBPATH; \
+	export WHICHPYTHON=$(PYTHON); \
 	bin/generate-greenplum-path.sh > $(DESTDIR)$(prefix)/greenplum_path.sh
 
 install: generate_greenplum_path_file

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 cat <<"EOF"
+#!/usr/bin/env bash
 if test -n "${ZSH_VERSION:-}"; then
     # zsh
     SCRIPT_PATH="${(%):-%x}"
@@ -26,9 +27,13 @@ else
 fi
 EOF
 
+cat <<EOF
+PYTHONBINDIR="$(dirname "${WHICHPYTHON}")"
+EOF
+
 cat <<"EOF"
 PYTHONPATH="${GPHOME}/lib/python"
-PATH="${GPHOME}/bin:${PATH}"
+PATH="${GPHOME}/bin:${PYTHONBINDIR}:${PATH}"
 LD_LIBRARY_PATH="${GPHOME}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
 if [ -e "${GPHOME}/etc/openssl.cnf" ]; then

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -19,6 +19,9 @@ fi
 #CMDPATH is the list of locations to search for commands, in precedence order
 declare -a CMDPATH
 CMDPATH=(/usr/kerberos/bin /usr/sfw/bin /opt/sfw/bin /usr/local/bin /bin /usr/bin /sbin /usr/sbin /usr/ucb /sw/bin)
+if hash brew 2> /dev/null; then
+  CMDPATH+=("$(brew --prefix)/bin")
+fi
 
 #GPPATH is the list of possible locations for the Cloudberry Database binaries, in precedence order
 declare -a GPPATH
@@ -900,7 +903,7 @@ GET_PG_PID_ACTIVE () {
 			if [ $RETVAL -ne 0 ];then
 				PID=0
 			else
-				PORT_ARRAY=($( REMOTE_EXECUTE_AND_GET_OUTPUT $HOST $SS -an 2>/dev/null |$AWK '{for (i =1; i<=NF ; i++) if ($i==".s.PGSQL.${PORT}") print $i}'|$AWK -F"." '{print $NF}'|$SORT -u))
+				PORT_ARRAY=($( REMOTE_EXECUTE_AND_GET_OUTPUT $HOST "$SS -an 2>/dev/null |$AWK '{for (i =1; i<=NF ; i++) if (\$i==\".s.PGSQL.${PORT}\") print \$i}'|$AWK -F\".\" '{print \$NF}'|$SORT -u"))
 				for P_CHK in ${PORT_ARRAY[@]}
 				do
 					if [ $P_CHK -eq $PORT ];then  PG_LOCK_NETSTAT=$PORT;fi

--- a/readmes/README.macOS.bash
+++ b/readmes/README.macOS.bash
@@ -4,17 +4,25 @@ echo "Caching password..."
 sudo -K
 sudo true;
 
+if [ ! -d /tmp/cbdb-devenv ] ; then
+  mkdir /tmp/cbdb-devenv && cd /tmp/cbdb-devenv || exit
+fi
+
 if hash brew 2>/dev/null; then
-	echo "Homebrew is already installed!"
+  echo "Homebrew is already installed!"
 else
-	echo "Installing Homebrew..."
-	ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+  echo "Installing Homebrew..."
+  echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  if [ $? -eq 1 ]; then
+        echo "ERROR : Homebrew Installation Failed, fix the failure and re-run the script."
+        exit 1
+  fi
 fi
 
 brew install bash-completion
 brew install conan
 brew install cmake # gporca
-brew install xerces-c #gporca
+#brew install xerces-c #gporca
 brew install libyaml # enables `--enable-mapreduce`
 brew install libevent # gpfdist
 brew install apr # gpfdist
@@ -24,16 +32,30 @@ brew install pkg-config
 brew install perl
 brew link --force apr
 brew link --force apr-util
+brew install gcc@13
+brew install gnu-sed
+
+#Install xerces-c  library
+if [ ! -d /tmp/cbdb-devenv/gp-xerces ] ; then
+  echo "INFO: xerces is not installed, Installing...."
+  git clone https://github.com/greenplum-db/gp-xerces.git -v /tmp/cbdb-devenv/gp-xerces
+  mkdir /tmp/cbdb-devenv/gp-xerces/build
+  cd /tmp/cbdb-devenv/gp-xerces/build || exit
+  /tmp/cbdb-devenv/gp-xerces/configure --prefix="$(brew --prefix)"
+  make -j"$(nproc)"
+  make install
+  cd - || exit
+fi
 
 # Needed for pygresql, or you can source greenplum_path.sh after compiling database and installing python-dependencies then
-brew install postgresql
+brew install postgresql@14
 
 brew install python3
 
 # Due to recent update on OS net-tools package. Mac doesn't have support for ss and ip by default.
 # Hence as a workaround installing iproute2mac for ip support and creating soft link for ss support
 brew install iproute2mac
-sudo ln -s /usr/sbin/netstat /usr/local/bin/ss
+sudo ln -s /usr/sbin/netstat "$(brew --prefix)"/bin/ss
 
 echo 127.0.0.1$'\t'$HOSTNAME | sudo tee -a /etc/hosts
 
@@ -70,15 +92,15 @@ net.inet.tcp.recvspace=262144
 kern.ipc.maxsockbuf=8388608
 EOF
 
-# Create GPDB destination directory
-sudo mkdir /usr/local/gpdb
-sudo chown $USER:admin /usr/local/gpdb
-
 # Configure
 cat >> ~/.bashrc << EOF
-ulimit -n 65536 65536  # Increases the number of open files
+ulimit -n 131072 131072  # Increases the number of open files
 export PGHOST="$(hostname)"
 export LC_CTYPE="en_US.UTF-8"
+EOF
+
+cat >> ~/.zshrc << EOF
+source ~/.bashrc
 EOF
 
 cat << EOF


### PR DESCRIPTION
### Change logs

Fix unportable scripts on macOS

1. Regarding `greenplum_path.sh`: In some platforms (notably macOS), various Python installations may co-exist. When `demo_cluster.sh` creates segments using ssh, it may not run by the same Python installation as the coordinator because env are not passed through, causing the super weird `"Module 'pgdb' not found"` error. This PR fix this by probing the path of the Python installation and write it down in `greenplum_path.sh`.
2. `README.macOS.bash` and `gp_bash_functions.sh` are changed as well to properly create cluster on macOS.

### Why are the changes needed?

> [!IMPORTANT]
> **This PR is a by-product of #198. These two PR are necessary to support CBDB building and running on macOS platform.**

### Does this PR introduce any user-facing change?

Before this PR, user cannot run `make create-demo-cluster` on macOS. Now they can.