### PR TITLE
Add vacuum full in serverless

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -2186,6 +2186,11 @@ vacuum_rel(Oid relid, RangeVar *relation, VacuumParams *params,
 	int			save_nestlevel;
 	bool		is_appendoptimized;
 	bool		is_toast;
+	bool		shouldDispatch;
+
+	shouldDispatch = (Gp_role == GP_ROLE_DISPATCH &&
+					ENABLE_DISPATCH() &&
+					!enable_serverless);
 
 	Assert(params != NULL);
 
@@ -2687,7 +2692,7 @@ vacuum_rel(Oid relid, RangeVar *relation, VacuumParams *params,
 	 * Don't dispatch auto-vacuum. Each segment performs auto-vacuum as per
 	 * its own need.
 	 */
-	if (Gp_role == GP_ROLE_DISPATCH && !recursing &&
+	if (shouldDispatch && !recursing &&
 		!IsAutoVacuumWorkerProcess() &&
 		(!is_appendoptimized || ao_vacuum_phase))
 	{

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -3754,6 +3754,10 @@ CreateCommandTag(Node *parsetree)
 			tag = CMDTAG_DROP_WAREHOUSE;
 			break;
 
+		case T_ExtensibleNode:
+			tag = CMDTAG_EXTENSIBLE;
+			break;
+
 		default:
 			elog(WARNING, "unrecognized node type: %d",
 				 (int) nodeTag(parsetree));

--- a/src/include/tcop/cmdtaglist.h
+++ b/src/include/tcop/cmdtaglist.h
@@ -208,6 +208,7 @@ PG_CMDTAG(CMDTAG_DROP_WAREHOUSE, "DROP WAREHOUSE", true, false, false)
 
 PG_CMDTAG(CMDTAG_EXECUTE, "EXECUTE", false, false, false)
 PG_CMDTAG(CMDTAG_EXPLAIN, "EXPLAIN", false, false, false)
+PG_CMDTAG(CMDTAG_EXTENSIBLE, "EXTENSIBLE", false, false, false)
 PG_CMDTAG(CMDTAG_FAULT_INJECT, "FAULT_INJECT", false, false, false)
 PG_CMDTAG(CMDTAG_FETCH, "FETCH", false, false, true)
 PG_CMDTAG(CMDTAG_GRANT, "GRANT", true, false, false)


### PR DESCRIPTION
1. In serverless architecture, we do not need to dispatch the vacuum command.
2. Make T_ExtensibleNode in CMD_TAG list, which is needed by CreateCommandTag inutility.c. We can not hook it because it executes before standard_ProcessUtility function.


---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to @cloudberrydb/dev team for review and approval when your PR is ready🥳
