### PR TITLE
change storage_am related catalog table main_manifest field type from…

### DIFF
--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -1546,7 +1546,7 @@ doDeletion(const ObjectAddress *object, int flags)
 			RemoveTaskById(object->objectId);
 			break;
 		case OCLASS_MAIN_MANIFEST:
-			RemoveMainManifestByRelid(object->objectId);
+			RemoveMainManifestByRelnode(object->objectId);
 			break;
 
 		case OCLASS_CAST:

--- a/src/backend/catalog/main_manifest.c
+++ b/src/backend/catalog/main_manifest.c
@@ -25,7 +25,7 @@
  *      Remove the main manifest record for the relid.
  */
 void
-RemoveMainManifestByRelid(Oid relid)
+RemoveMainManifestByRelid(RelFileNodeId relnode)
 {
     Relation    main_manifest;
     HeapTuple   tuple;
@@ -33,8 +33,8 @@ RemoveMainManifestByRelid(Oid relid)
     ScanKeyData scanKey[1];
 
     main_manifest = table_open(ManifestRelationId, RowExclusiveLock);
-    ScanKeyInit(&scanKey[0], Anum_main_manifest_relid, BTEqualStrategyNumber,
-                F_OIDEQ, ObjectIdGetDatum(relid));
+    ScanKeyInit(&scanKey[0], Anum_main_manifest_relnode, BTEqualStrategyNumber,
+                F_OIDEQ, ObjectIdGetDatum(relnode));
 
     scanDescriptor = systable_beginscan(main_manifest, InvalidOid,
                                         false, NULL, 1, scanKey);

--- a/src/backend/catalog/main_manifest.c
+++ b/src/backend/catalog/main_manifest.c
@@ -21,11 +21,11 @@
 #include "utils/rel.h"
 
 /*
- * RemoveMainManifestByRelid
- *      Remove the main manifest record for the relid.
+ * RemoveMainManifestByRelnode
+ *      Remove the main manifest record for the relnode.
  */
 void
-RemoveMainManifestByRelid(RelFileNodeId relnode)
+RemoveMainManifestByRelnode(RelFileNodeId relnode)
 {
     Relation    main_manifest;
     HeapTuple   tuple;

--- a/src/include/catalog/main_manifest.h
+++ b/src/include/catalog/main_manifest.h
@@ -30,6 +30,6 @@ CATALOG(main_manifest,9004,ManifestRelationId) BKI_SHARED_RELATION
 
 typedef FormData_main_manifest *Form_main_manifest;
 
-extern void RemoveMainManifestByRelid(RelFileNodeId relnode);
+extern void RemoveMainManifestByRelnode(RelFileNodeId relnode);
 
 #endif /* MAIN_MANIFEST.h */

--- a/src/include/catalog/main_manifest.h
+++ b/src/include/catalog/main_manifest.h
@@ -24,12 +24,12 @@
  */
 CATALOG(main_manifest,9004,ManifestRelationId) BKI_SHARED_RELATION
 {
-	Oid			relid;
+	RelFileNodeId	relnode;
 	text		path;
 } FormData_main_manifest;
 
 typedef FormData_main_manifest *Form_main_manifest;
 
-extern void RemoveMainManifestByRelid(Oid relid);
+extern void RemoveMainManifestByRelid(RelFileNodeId relnode);
 
 #endif /* MAIN_MANIFEST.h */


### PR DESCRIPTION
… uint32 to uint64,

and change the name from relid to relnode

we did the same change on storage_am, the main_manifest is a system catalog,  storage_am has dependencies on this change.
storage_am will use the relfilenode as the identifier instead of relid, and currenlty relfilenode is uint64 and relid is uint32.

