### PR TITLE
Fix incorrect index->reltuples after VACUUM

### DIFF
--- a/src/backend/access/nbtree/nbtpage.c
+++ b/src/backend/access/nbtree/nbtpage.c
@@ -36,6 +36,7 @@
 #include "utils/memdebug.h"
 #include "utils/memutils.h"
 #include "utils/snapmgr.h"
+#include "commands/vacuum.h"
 
 static BTMetaPageData *_bt_getmeta(Relation rel, Buffer metabuf);
 static void _bt_log_reuse_page(Relation rel, BlockNumber blkno,
@@ -185,6 +186,10 @@ _bt_vacuum_needs_cleanup(Relation rel)
 	BTMetaPageData *metad;
 	uint32		btm_version;
 	BlockNumber prev_num_delpages;
+
+	/* Return true directly on QE for stats collection from QD. */
+	if (gp_vacuum_needs_update_stats())
+		return true;
 
 	/*
 	 * Copy details from metapage to local variables quickly.

--- a/src/backend/access/nbtree/nbtree.c
+++ b/src/backend/access/nbtree/nbtree.c
@@ -878,6 +878,75 @@ _bt_parallel_advance_array_keys(IndexScanDesc scan)
 }
 
 /*
+ * _bt_vacuum_needs_cleanup() -- Checks if index needs cleanup assuming that
+ *			btbulkdelete() wasn't called.
+ */
+static bool
+_bt_vacuum_needs_cleanup(IndexVacuumInfo *info)
+{
+	Buffer		metabuf;
+	Page		metapg;
+	BTMetaPageData *metad;
+	bool		result = false;
+
+	/* Return true directly on QE for stats collection from QD. */
+	if (gp_vacuum_needs_update_stats())
+		return true;
+
+	metabuf = _bt_getbuf(info->index, BTREE_METAPAGE, BT_READ);
+	metapg = BufferGetPage(metabuf);
+	metad = BTPageGetMeta(metapg);
+
+	if (metad->btm_version < BTREE_NOVAC_VERSION)
+	{
+		/*
+		 * Do cleanup if metapage needs upgrade, because we don't have
+		 * cleanup-related meta-information yet.
+		 */
+		result = true;
+	}
+	else if (TransactionIdIsValid(metad->btm_oldest_btpo_xact) &&
+			 TransactionIdPrecedes(metad->btm_oldest_btpo_xact,
+								   RecentGlobalXmin))
+	{
+		/*
+		 * If oldest btpo.xact in the deleted pages is older than
+		 * RecentGlobalXmin, then at least one deleted page can be recycled.
+		 */
+		result = true;
+	}
+	else
+	{
+		StdRdOptions *relopts;
+		float8		cleanup_scale_factor;
+		float8		prev_num_heap_tuples;
+
+		/*
+		 * If table receives enough insertions and no cleanup was performed,
+		 * then index would appear have stale statistics.  If scale factor is
+		 * set, we avoid that by performing cleanup if the number of inserted
+		 * tuples exceeds vacuum_cleanup_index_scale_factor fraction of
+		 * original tuples count.
+		 */
+		relopts = (StdRdOptions *) info->index->rd_options;
+		cleanup_scale_factor = (relopts &&
+								relopts->vacuum_cleanup_index_scale_factor >= 0)
+			? relopts->vacuum_cleanup_index_scale_factor
+			: vacuum_cleanup_index_scale_factor;
+		prev_num_heap_tuples = metad->btm_last_cleanup_num_heap_tuples;
+
+		if (cleanup_scale_factor <= 0 ||
+			prev_num_heap_tuples <= 0 ||
+			(info->num_heap_tuples - prev_num_heap_tuples) /
+			prev_num_heap_tuples >= cleanup_scale_factor)
+			result = true;
+	}
+
+	_bt_relbuf(info->index, metabuf);
+	return result;
+}
+
+/*
  * Bulk deletion of all index entries pointing to a set of heap tuples.
  * The set of target tuples is specified via a callback routine that tells
  * whether any given heap tuple (identified by ItemPointer) is being deleted.

--- a/src/backend/cdb/dispatcher/cdbdispatchresult.c
+++ b/src/backend/cdb/dispatcher/cdbdispatchresult.c
@@ -821,6 +821,8 @@ cdbdisp_returnResults(CdbDispatchResults *primaryResults, CdbPgResults *cdb_pgre
 
 	/* tell the caller how many sets we're returning. */
 	cdb_pgresults->numResults = nresults;
+	/* set the number of dispatched QE */
+	cdb_pgresults->numDispatches = primaryResults->resultCount;
 }
 
 /*

--- a/src/include/cdb/cdbdispatchresult.h
+++ b/src/include/cdb/cdbdispatchresult.h
@@ -29,6 +29,7 @@ typedef struct CdbPgResults
 {
 	struct pg_result **pg_results;
 	int numResults;
+	int numDispatches; /* the number of dispatched QE, from CdbDispatchResults.resultCount */
 }CdbPgResults;
 
 /*

--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -258,6 +258,16 @@ typedef struct VPgClassStats
 	BlockNumber relallvisible;
 } VPgClassStats;
 
+typedef struct VPgClassStatsCombo
+{
+	Oid			relid;
+	BlockNumber rel_pages;
+	double		rel_tuples;
+	BlockNumber relallvisible;
+
+	int			count; /* expect to equal to the number of dispatched segments */
+} VPgClassStatsCombo;
+
 /*
  * Parameters customizing behavior of VACUUM and ANALYZE.
  *
@@ -386,6 +396,7 @@ extern void analyze_rel(Oid relid, RangeVar *relation,
 extern void lazy_vacuum_rel_heap(Relation onerel,
 							VacuumParams *params, BufferAccessStrategy bstrategy);
 extern void scan_index(Relation indrel, Relation aorel, int elevel, BufferAccessStrategy bstrategy);
+
 /* in commands/vacuum_ao.c */
 extern void ao_vacuum_rel(Relation rel, VacuumParams *params, BufferAccessStrategy bstrategy);
 
@@ -406,5 +417,7 @@ extern int acquire_inherited_sample_rows(Relation onerel, int elevel,
 /* in commands/analyzefuncs.c */
 extern Datum gp_acquire_sample_rows(PG_FUNCTION_ARGS);
 extern Oid gp_acquire_sample_rows_col_type(Oid typid);
+
+extern bool gp_vacuum_needs_update_stats(void);
 
 #endif							/* VACUUM_H */

--- a/src/test/regress/expected/btree_index.out
+++ b/src/test/regress/expected/btree_index.out
@@ -344,7 +344,7 @@ INSERT INTO btree_stats_tbl VALUES (1, 'aa', 1001, 101), (2, 'bb', 1002, 102);
 SELECT reltuples FROM pg_class WHERE relname='btree_stats_tbl';
  reltuples 
 -----------
-         0
+        -1
 (1 row)
 
 -- inspect the state of the stats on segments

--- a/src/test/regress/expected/btree_index.out
+++ b/src/test/regress/expected/btree_index.out
@@ -335,18 +335,112 @@ VACUUM delete_test_table;
 -- The vacuum above should've turned the leaf page into a fast root. We just
 -- need to insert some rows to cause the fast root page to split.
 INSERT INTO delete_test_table SELECT i, 1, 2, 3 FROM generate_series(1,1000) i;
--- Test unsupported btree opclass parameters
-create index on btree_tall_tbl (id int4_ops(foo=1));
-ERROR:  operator class int4_ops has no options
--- Test case of ALTER INDEX with abuse of column names for indexes.
--- This grammar is not officially supported, but the parser allows it.
-CREATE INDEX btree_tall_idx2 ON btree_tall_tbl (id);
-ALTER INDEX btree_tall_idx2 ALTER COLUMN id SET (n_distinct=100);
-ERROR:  "btree_tall_idx2" is not a table, materialized view, or foreign table
-DROP INDEX btree_tall_idx2;
--- Partitioned index
-CREATE TABLE btree_part (id int4) PARTITION BY RANGE (id);
-CREATE INDEX btree_part_idx ON btree_part(id);
-ALTER INDEX btree_part_idx ALTER COLUMN id SET (n_distinct=100);
-ERROR:  "btree_part_idx" is not a table, materialized view, or foreign table
-DROP TABLE btree_part;
+--
+-- GPDB: Test correctness of B-tree stats in consecutively VACUUM.
+--
+CREATE TABLE btree_stats_tbl(col_int int, col_text text, col_numeric numeric, col_unq int) DISTRIBUTED BY (col_int);
+CREATE INDEX btree_stats_idx ON btree_stats_tbl(col_int);
+INSERT INTO btree_stats_tbl VALUES (1, 'aa', 1001, 101), (2, 'bb', 1002, 102);
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_tbl';
+ reltuples 
+-----------
+         0
+(1 row)
+
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'btree_stats_idx';
+ gp_segment_id |     relname     | reltuples 
+---------------+-----------------+-----------
+             0 | btree_stats_idx |         0
+             1 | btree_stats_idx |         0
+             2 | btree_stats_idx |         0
+(3 rows)
+
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_idx';
+ reltuples 
+-----------
+         0
+(1 row)
+
+-- 1st VACUUM, expect reltuples = 2
+vacuum btree_stats_tbl;
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_tbl';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'btree_stats_idx';
+ gp_segment_id |     relname     | reltuples 
+---------------+-----------------+-----------
+             0 | btree_stats_idx |         1
+             1 | btree_stats_idx |         1
+             2 | btree_stats_idx |         0
+(3 rows)
+
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_idx';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- 2nd VACUUM, expect reltuples = 2
+vacuum btree_stats_tbl;
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_tbl';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'btree_stats_idx';
+ gp_segment_id |     relname     | reltuples 
+---------------+-----------------+-----------
+             0 | btree_stats_idx |         1
+             1 | btree_stats_idx |         1
+             2 | btree_stats_idx |         0
+(3 rows)
+
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_idx';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- Prior to this fix, the case would be failed here. Given the
+-- scenario of updating stats during VACUUM:
+-- 1) coordinator vacuums and updates stats of its own;
+-- 2) then coordinator dispatches vacuum to segments;
+-- 3) coordinator combines stats received from segments to overwrite the stats of its own.
+-- Because upstream introduced a feature which could skip full index scan uring cleanup
+-- of B-tree indexes when possible (refer to:
+-- https://github.com/postgres/postgres/commit/857f9c36cda520030381bd8c2af20adf0ce0e1d4),
+-- there was a case in QD-QEs distributed deployment that some QEs could skip full index scan and
+-- stop updating statistics, result in QD being unable to collect all QEs' stats thus overwrote
+-- a paritial accumulated value to index->reltuples. More interesting, it usually happened starting
+-- from the 3rd time of consecutively VACUUM after fresh inserts due to above skipping index scan
+-- criteria.
+-- 3rd VACUUM, expect reltuples = 2
+vacuum btree_stats_tbl;
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_tbl';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'btree_stats_idx';
+ gp_segment_id |     relname     | reltuples 
+---------------+-----------------+-----------
+             0 | btree_stats_idx |         1
+             1 | btree_stats_idx |         1
+             2 | btree_stats_idx |         0
+(3 rows)
+
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_idx';
+ reltuples 
+-----------
+         2
+(1 row)
+

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -2469,9 +2469,7 @@ select count(*) from
                ->  Gather Motion 3:1  (slice2; segments: 3)
                      Merge Key: y.unique2
                      ->  Subquery Scan on y
-                           ->  Sort
-                                 Sort Key: y_1.unique2
-                                 ->  Seq Scan on tenk1 y_1
+                           ->  Index Scan using tenk1_unique2 on tenk1 y_1
  Optimizer: Postgres query optimizer
 (18 rows)
 

--- a/src/test/regress/expected/memoize.out
+++ b/src/test/regress/expected/memoize.out
@@ -39,23 +39,23 @@ SELECT explain_memoize('
 SELECT COUNT(*),AVG(t1.unique1) FROM tenk1 t1
 INNER JOIN tenk1 t2 ON t1.unique1 = t2.twenty
 WHERE t2.unique1 < 1000;', false);
-                                            explain_memoize                                             
---------------------------------------------------------------------------------------------------------
+                                            explain_memoize                                            
+-------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=N)
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=N)
          ->  Partial Aggregate (actual rows=1 loops=N)
-               ->  Merge Join (actual rows=400 loops=N)
-                     Merge Cond: (t1.unique1 = t2.twenty)
-                     ->  Index Only Scan using tenk1_unique1 on tenk1 t1 (actual rows=9 loops=N)
-                           Heap Fetches: N
-                     ->  Sort (actual rows=400 loops=N)
-                           Sort Key: t2.twenty
-                           Sort Method:  quicksort  Memory: NkB
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual rows=400 loops=N)
-                                 Hash Key: t2.twenty
-                                 ->  Seq Scan on tenk1 t2 (actual rows=340 loops=N)
-                                       Filter: (unique1 < 1000)
-                                       Rows Removed by Filter: 2906
+               ->  Nested Loop (actual rows=400 loops=N)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual rows=400 loops=N)
+                           Hash Key: t2.twenty
+                           ->  Seq Scan on tenk1 t2 (actual rows=340 loops=N)
+                                 Filter: (unique1 < 1000)
+                                 Rows Removed by Filter: 2906
+                     ->  Memoize (actual rows=1 loops=N)
+                           Cache Key: t2.twenty
+                           Cache Mode: logical
+                           ->  Index Only Scan using tenk1_unique1 on tenk1 t1 (actual rows=1 loops=N)
+                                 Index Cond: (unique1 = t2.twenty)
+                                 Heap Fetches: N
  Optimizer: Postgres query optimizer
 (16 rows)
 
@@ -73,23 +73,23 @@ SELECT explain_memoize('
 SELECT COUNT(*),AVG(t2.unique1) FROM tenk1 t1,
 LATERAL (SELECT t2.unique1 FROM tenk1 t2 WHERE t1.twenty = t2.unique1) t2
 WHERE t1.unique1 < 1000;', false);
-                                            explain_memoize                                             
---------------------------------------------------------------------------------------------------------
+                                            explain_memoize                                            
+-------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=N)
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=N)
          ->  Partial Aggregate (actual rows=1 loops=N)
-               ->  Merge Join (actual rows=400 loops=N)
-                     Merge Cond: (t2.unique1 = t1.twenty)
-                     ->  Index Only Scan using tenk1_unique1 on tenk1 t2 (actual rows=9 loops=N)
-                           Heap Fetches: N
-                     ->  Sort (actual rows=400 loops=N)
-                           Sort Key: t1.twenty
-                           Sort Method:  quicksort  Memory: NkB
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual rows=400 loops=N)
-                                 Hash Key: t1.twenty
-                                 ->  Seq Scan on tenk1 t1 (actual rows=340 loops=N)
-                                       Filter: (unique1 < 1000)
-                                       Rows Removed by Filter: 2906
+               ->  Nested Loop (actual rows=400 loops=N)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual rows=400 loops=N)
+                           Hash Key: t1.twenty
+                           ->  Seq Scan on tenk1 t1 (actual rows=340 loops=N)
+                                 Filter: (unique1 < 1000)
+                                 Rows Removed by Filter: 2906
+                     ->  Memoize (actual rows=1 loops=N)
+                           Cache Key: t1.twenty
+                           Cache Mode: logical
+                           ->  Index Only Scan using tenk1_unique1 on tenk1 t2 (actual rows=1 loops=N)
+                                 Index Cond: (unique1 = t1.twenty)
+                                 Heap Fetches: N
  Optimizer: Postgres query optimizer
 (16 rows)
 
@@ -284,10 +284,12 @@ WHERE t1.unique1 < 1000;
                      ->  Hash
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Hash Key: t1.twenty
-                                 ->  Seq Scan on tenk1 t1
-                                       Filter: (unique1 < 1000)
+                                 ->  Bitmap Heap Scan on tenk1 t1
+                                       Recheck Cond: (unique1 < 1000)
+                                       ->  Bitmap Index Scan on tenk1_unique1
+                                             Index Cond: (unique1 < 1000)
  Optimizer: Postgres query optimizer
-(12 rows)
+(14 rows)
 
 -- And ensure the parallel plan gives us the correct results.
 SELECT COUNT(*),AVG(t2.unique1) FROM tenk1 t1,

--- a/src/test/regress/expected/memoize_optimizer.out
+++ b/src/test/regress/expected/memoize_optimizer.out
@@ -69,23 +69,23 @@ SELECT explain_memoize('
 SELECT COUNT(*),AVG(t2.unique1) FROM tenk1 t1,
 LATERAL (SELECT t2.unique1 FROM tenk1 t2 WHERE t1.twenty = t2.unique1) t2
 WHERE t1.unique1 < 1000;', false);
-                                            explain_memoize                                             
---------------------------------------------------------------------------------------------------------
+                                            explain_memoize                                            
+-------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=N)
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=N)
          ->  Partial Aggregate (actual rows=1 loops=N)
-               ->  Merge Join (actual rows=400 loops=N)
-                     Merge Cond: (t2.unique1 = t1.twenty)
-                     ->  Index Only Scan using tenk1_unique1 on tenk1 t2 (actual rows=9 loops=N)
-                           Heap Fetches: N
-                     ->  Sort (actual rows=400 loops=N)
-                           Sort Key: t1.twenty
-                           Sort Method:  quicksort  Memory: NkB
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual rows=400 loops=N)
-                                 Hash Key: t1.twenty
-                                 ->  Seq Scan on tenk1 t1 (actual rows=340 loops=N)
-                                       Filter: (unique1 < 1000)
-                                       Rows Removed by Filter: 2906
+               ->  Nested Loop (actual rows=400 loops=N)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual rows=400 loops=N)
+                           Hash Key: t1.twenty
+                           ->  Seq Scan on tenk1 t1 (actual rows=340 loops=N)
+                                 Filter: (unique1 < 1000)
+                                 Rows Removed by Filter: 2906
+                     ->  Memoize (actual rows=1 loops=N)
+                           Cache Key: t1.twenty
+                           Cache Mode: logical
+                           ->  Index Only Scan using tenk1_unique1 on tenk1 t2 (actual rows=1 loops=N)
+                                 Index Cond: (unique1 = t1.twenty)
+                                 Heap Fetches: N
  Optimizer: Postgres query optimizer
 (16 rows)
 
@@ -276,10 +276,12 @@ WHERE t1.unique1 < 1000;
                      ->  Hash
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Hash Key: t1.twenty
-                                 ->  Seq Scan on tenk1 t1
-                                       Filter: (unique1 < 1000)
+                                 ->  Bitmap Heap Scan on tenk1 t1
+                                       Recheck Cond: (unique1 < 1000)
+                                       ->  Bitmap Index Scan on tenk1_unique1
+                                             Index Cond: (unique1 < 1000)
  Optimizer: Postgres query optimizer
-(12 rows)
+(14 rows)
 
 -- And ensure the parallel plan gives us the correct results.
 SELECT COUNT(*),AVG(t2.unique1) FROM tenk1 t1,

--- a/src/test/regress/expected/misc_functions.out
+++ b/src/test/regress/expected/misc_functions.out
@@ -274,14 +274,13 @@ SELECT * FROM tenk1 a JOIN my_gen_series(1,1000) g ON a.unique1 = g;
 
 EXPLAIN (COSTS OFF)
 SELECT * FROM tenk1 a JOIN my_gen_series(1,10) g ON a.unique1 = g;
-                     QUERY PLAN                     
-----------------------------------------------------
+                      QUERY PLAN                       
+-------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Hash Join
-         Hash Cond: (a.unique1 = g.g)
-         ->  Seq Scan on tenk1 a
-         ->  Hash
-               ->  Function Scan on my_gen_series g
+   ->  Nested Loop
+         ->  Function Scan on my_gen_series g
+         ->  Index Scan using tenk1_unique1 on tenk1 a
+               Index Cond: (unique1 = g.g)
  Optimizer: Postgres query optimizer
-(7 rows)
+(6 rows)
 

--- a/src/test/regress/expected/select_parallel.out
+++ b/src/test/regress/expected/select_parallel.out
@@ -651,11 +651,9 @@ explain (costs off)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
                ->  Merge Join
-                     Merge Cond: (tenk2.unique1 = tenk1.unique1)
+                     Merge Cond: (tenk1.unique1 = tenk2.unique1)
+                     ->  Index Only Scan using tenk1_unique1 on tenk1
                      ->  Index Only Scan using tenk2_unique1 on tenk2
-                     ->  Sort
-                           Sort Key: tenk1.unique1
-                           ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer
 (10 rows)
 

--- a/src/test/regress/expected/uao_compaction/index_stats.out
+++ b/src/test/regress/expected/uao_compaction/index_stats.out
@@ -40,4 +40,164 @@ SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx1';
  mytab_int_idx1 |         2
 (1 row)
 
--- end_ignore
+-- Test to ensure that reltuples is updated for an index after lazy vacuum.
+-- This is vital as most index AMs that depend on this tuple count (eg btree, bitmap etc)
+-- which is passed up from the table AM during lazy vacuum.
+-- create a fresh table for the test
+CREATE TABLE mytab2(
+          col_int int,
+          col_text text,
+          col_numeric numeric,
+          col_unq int
+          ) with(appendonly=true) DISTRIBUTED BY (col_int);
+create index mytab2_int_idx1 on mytab2 using bitmap(col_int);
+insert into mytab2 values(1,'aa',1001,101),(2,'bb',1002,102);
+SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab2_int_idx1';
+     relname     | reltuples 
+-----------------+-----------
+ mytab2_int_idx1 |         0
+(1 row)
+
+-- first vacuum collect table stat on segments
+vacuum mytab2;
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'mytab2_int_idx1';
+ gp_segment_id |     relname     | reltuples 
+---------------+-----------------+-----------
+             0 | mytab2_int_idx1 |         0
+             1 | mytab2_int_idx1 |         0
+             2 | mytab2_int_idx1 |         0
+(3 rows)
+
+-- second vacuum update index stat with table stat
+vacuum mytab2;
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'mytab2_int_idx1';
+ gp_segment_id |     relname     | reltuples 
+---------------+-----------------+-----------
+             0 | mytab2_int_idx1 |         1
+             1 | mytab2_int_idx1 |         1
+             2 | mytab2_int_idx1 |         0
+(3 rows)
+
+SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab2_int_idx1';
+     relname     | reltuples 
+-----------------+-----------
+ mytab2_int_idx1 |         2
+(1 row)
+
+-- Test correctness of index->reltuples in consecutively VACUUM.
+CREATE TABLE mytab3(
+          col_int int,
+          col_text text,
+          col_numeric numeric,
+          col_unq int
+          ) with(appendonly=true) DISTRIBUTED BY (col_int);
+create index mytab3_int_idx1 on mytab3(col_int);
+insert into mytab3 values(1,'aa',1001,101),(2,'bb',1002,102);
+select reltuples from pg_class where relname='mytab3';
+ reltuples 
+-----------
+         0
+(1 row)
+
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'mytab3_int_idx1';
+ gp_segment_id |     relname     | reltuples 
+---------------+-----------------+-----------
+             0 | mytab3_int_idx1 |         0
+             1 | mytab3_int_idx1 |         0
+             2 | mytab3_int_idx1 |         0
+(3 rows)
+
+select reltuples from pg_class where relname='mytab3_int_idx1';
+ reltuples 
+-----------
+         0
+(1 row)
+
+-- 1st VACUUM, expect reltuples = 2
+vacuum mytab3;
+select reltuples from pg_class where relname='mytab3';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'mytab3_int_idx1';
+ gp_segment_id |     relname     | reltuples 
+---------------+-----------------+-----------
+             0 | mytab3_int_idx1 |         1
+             1 | mytab3_int_idx1 |         1
+             2 | mytab3_int_idx1 |         0
+(3 rows)
+
+select reltuples from pg_class where relname='mytab3_int_idx1';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- 2nd VACUUM, expect reltuples = 2
+vacuum mytab3;
+select reltuples from pg_class where relname='mytab3';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'mytab3_int_idx1';
+ gp_segment_id |     relname     | reltuples 
+---------------+-----------------+-----------
+             0 | mytab3_int_idx1 |         1
+             1 | mytab3_int_idx1 |         1
+             2 | mytab3_int_idx1 |         0
+(3 rows)
+
+select reltuples from pg_class where relname='mytab3_int_idx1';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- Prior to this fix, the case would be failed here. Given the
+-- scenario of updating stats during VACUUM:
+-- 1) coordinator vacuums and updates stats of its own;
+-- 2) then coordinator dispatches vacuum to segments;
+-- 3) coordinator combines stats received from segments to overwrite the stats of its own.
+-- Because upstream introduced a feature which could skip full index scan uring cleanup
+-- of B-tree indexes when possible (refer to:
+-- https://github.com/postgres/postgres/commit/857f9c36cda520030381bd8c2af20adf0ce0e1d4),
+-- there was a case in QD-QEs distributed deployment that some QEs could skip full index scan and
+-- stop updating statistics, result in QD being unable to collect all QEs' stats thus overwrote
+-- a paritial accumulated value to index->reltuples. More interesting, it usually happened starting
+-- from the 3rd time of consecutively VACUUM after fresh inserts due to above skipping index scan
+-- criteria.
+-- 3rd VACUUM, expect reltuples = 2
+vacuum mytab3;
+select reltuples from pg_class where relname='mytab3';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'mytab3_int_idx1';
+ gp_segment_id |     relname     | reltuples 
+---------------+-----------------+-----------
+             0 | mytab3_int_idx1 |         1
+             1 | mytab3_int_idx1 |         1
+             2 | mytab3_int_idx1 |         0
+(3 rows)
+
+select reltuples from pg_class where relname='mytab3_int_idx1';
+ reltuples 
+-----------
+         2
+(1 row)
+
+drop table mytab;
+drop table mytab2;
+drop table mytab3;

--- a/src/test/regress/expected/uaocs_compaction/index_stats.out
+++ b/src/test/regress/expected/uaocs_compaction/index_stats.out
@@ -45,4 +45,164 @@ SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_i
  uaocs_index_stats_int_idx1 |         2
 (1 row)
 
--- end_ignore
+-- Test to ensure that reltuples is updated for an index after lazy vacuum.
+-- This is vital as most index AMs that depend on this tuple count (eg btree, bitmap etc)
+-- which is passed up from the table AM during lazy vacuum.
+-- create a fresh table for the test
+CREATE TABLE uaocs_index_stats2(
+          col_int int,
+          col_text text,
+          col_numeric numeric,
+          col_unq int
+          ) with(appendonly=true, orientation=column) DISTRIBUTED BY (col_int);
+create index uaocs_index_stats2_int_idx1 on uaocs_index_stats2 using bitmap(col_int);
+insert into uaocs_index_stats2 values(1,'aa',1001,101),(2,'bb',1002,102);
+SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats2_int_idx1';
+           relname           | reltuples 
+-----------------------------+-----------
+ uaocs_index_stats2_int_idx1 |         0
+(1 row)
+
+-- first vacuum collect table stat on segments
+vacuum uaocs_index_stats2;
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'uaocs_index_stats2_int_idx1';
+ gp_segment_id |           relname           | reltuples 
+---------------+-----------------------------+-----------
+             0 | uaocs_index_stats2_int_idx1 |         0
+             1 | uaocs_index_stats2_int_idx1 |         0
+             2 | uaocs_index_stats2_int_idx1 |         0
+(3 rows)
+
+-- second vacuum update index stat with table stat
+vacuum uaocs_index_stats2;
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'uaocs_index_stats2_int_idx1';
+ gp_segment_id |           relname           | reltuples 
+---------------+-----------------------------+-----------
+             0 | uaocs_index_stats2_int_idx1 |         1
+             1 | uaocs_index_stats2_int_idx1 |         1
+             2 | uaocs_index_stats2_int_idx1 |         0
+(3 rows)
+
+SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats2_int_idx1';
+           relname           | reltuples 
+-----------------------------+-----------
+ uaocs_index_stats2_int_idx1 |         2
+(1 row)
+
+-- Test correctness of index->reltuples in consecutively VACUUM.
+CREATE TABLE uaocs_index_stats3(
+          col_int int,
+          col_text text,
+          col_numeric numeric,
+          col_unq int
+          ) with(appendonly=true, orientation=column) DISTRIBUTED BY (col_int);
+create index uaocs_index_stats3_int_idx1 on uaocs_index_stats3(col_int);
+insert into uaocs_index_stats3 values(1,'aa',1001,101),(2,'bb',1002,102);
+select reltuples from pg_class where relname='uaocs_index_stats3';
+ reltuples 
+-----------
+         0
+(1 row)
+
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'uaocs_index_stats3_int_idx1';
+ gp_segment_id |           relname           | reltuples 
+---------------+-----------------------------+-----------
+             0 | uaocs_index_stats3_int_idx1 |         0
+             1 | uaocs_index_stats3_int_idx1 |         0
+             2 | uaocs_index_stats3_int_idx1 |         0
+(3 rows)
+
+select reltuples from pg_class where relname='uaocs_index_stats3_int_idx1';
+ reltuples 
+-----------
+         0
+(1 row)
+
+-- 1st VACUUM, expect reltuples = 2
+vacuum uaocs_index_stats3;
+select reltuples from pg_class where relname='uaocs_index_stats';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'uaocs_index_stats3_int_idx1';
+ gp_segment_id |           relname           | reltuples 
+---------------+-----------------------------+-----------
+             0 | uaocs_index_stats3_int_idx1 |         1
+             1 | uaocs_index_stats3_int_idx1 |         1
+             2 | uaocs_index_stats3_int_idx1 |         0
+(3 rows)
+
+select reltuples from pg_class where relname='uaocs_index_stats3_int_idx1';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- 2nd VACUUM, expect reltuples = 2
+vacuum uaocs_index_stats3;
+select reltuples from pg_class where relname='uaocs_index_stats3';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'uaocs_index_stats3_int_idx1';
+ gp_segment_id |           relname           | reltuples 
+---------------+-----------------------------+-----------
+             0 | uaocs_index_stats3_int_idx1 |         1
+             1 | uaocs_index_stats3_int_idx1 |         1
+             2 | uaocs_index_stats3_int_idx1 |         0
+(3 rows)
+
+select reltuples from pg_class where relname='uaocs_index_stats3_int_idx1';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- Prior to this fix, the case would be failed here. Given the
+-- scenario of updating stats during VACUUM:
+-- 1) coordinator vacuums and updates stats of its own;
+-- 2) then coordinator dispatches vacuum to segments;
+-- 3) coordinator combines stats received from segments to overwrite the stats of its own.
+-- Because upstream introduced a feature which could skip full index scan uring cleanup
+-- of B-tree indexes when possible (refer to:
+-- https://github.com/postgres/postgres/commit/857f9c36cda520030381bd8c2af20adf0ce0e1d4),
+-- there was a case in QD-QEs distributed deployment that some QEs could skip full index scan and
+-- stop updating statistics, result in QD being unable to collect all QEs' stats thus overwrote
+-- a paritial accumulated value to index->reltuples. More interesting, it usually happened starting
+-- from the 3rd time of consecutively VACUUM after fresh inserts due to above skipping index scan
+-- criteria.
+-- 3rd VACUUM, expect reltuples = 2
+vacuum uaocs_index_stats3;
+select reltuples from pg_class where relname='uaocs_index_stats3';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'uaocs_index_stats3_int_idx1';
+ gp_segment_id |           relname           | reltuples 
+---------------+-----------------------------+-----------
+             0 | uaocs_index_stats3_int_idx1 |         1
+             1 | uaocs_index_stats3_int_idx1 |         1
+             2 | uaocs_index_stats3_int_idx1 |         0
+(3 rows)
+
+select reltuples from pg_class where relname='uaocs_index_stats3_int_idx1';
+ reltuples 
+-----------
+         2
+(1 row)
+
+drop table uaocs_index_stats;
+drop table uaocs_index_stats2;
+drop table uaocs_index_stats3;

--- a/src/test/regress/sql/uao_compaction/index_stats.sql
+++ b/src/test/regress/sql/uao_compaction/index_stats.sql
@@ -23,4 +23,83 @@ SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab';
 -- for reltuples to coordinate with the new behavior.
 -- start_ignore
 SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx1';
--- end_ignore
+
+-- Test to ensure that reltuples is updated for an index after lazy vacuum.
+-- This is vital as most index AMs that depend on this tuple count (eg btree, bitmap etc)
+-- which is passed up from the table AM during lazy vacuum.
+-- create a fresh table for the test
+CREATE TABLE mytab2(
+          col_int int,
+          col_text text,
+          col_numeric numeric,
+          col_unq int
+          ) with(appendonly=true) DISTRIBUTED BY (col_int);
+
+create index mytab2_int_idx1 on mytab2 using bitmap(col_int);
+
+insert into mytab2 values(1,'aa',1001,101),(2,'bb',1002,102);
+
+SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab2_int_idx1';
+
+-- first vacuum collect table stat on segments
+vacuum mytab2;
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'mytab2_int_idx1';
+-- second vacuum update index stat with table stat
+vacuum mytab2;
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'mytab2_int_idx1';
+SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab2_int_idx1';
+
+-- Test correctness of index->reltuples in consecutively VACUUM.
+CREATE TABLE mytab3(
+          col_int int,
+          col_text text,
+          col_numeric numeric,
+          col_unq int
+          ) with(appendonly=true) DISTRIBUTED BY (col_int);
+
+create index mytab3_int_idx1 on mytab3(col_int);
+
+insert into mytab3 values(1,'aa',1001,101),(2,'bb',1002,102);
+
+select reltuples from pg_class where relname='mytab3';
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'mytab3_int_idx1';
+select reltuples from pg_class where relname='mytab3_int_idx1';
+-- 1st VACUUM, expect reltuples = 2
+vacuum mytab3;
+select reltuples from pg_class where relname='mytab3';
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'mytab3_int_idx1';
+select reltuples from pg_class where relname='mytab3_int_idx1';
+-- 2nd VACUUM, expect reltuples = 2
+vacuum mytab3;
+select reltuples from pg_class where relname='mytab3';
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'mytab3_int_idx1';
+select reltuples from pg_class where relname='mytab3_int_idx1';
+
+-- Prior to this fix, the case would be failed here. Given the
+-- scenario of updating stats during VACUUM:
+-- 1) coordinator vacuums and updates stats of its own;
+-- 2) then coordinator dispatches vacuum to segments;
+-- 3) coordinator combines stats received from segments to overwrite the stats of its own.
+-- Because upstream introduced a feature which could skip full index scan uring cleanup
+-- of B-tree indexes when possible (refer to:
+-- https://github.com/postgres/postgres/commit/857f9c36cda520030381bd8c2af20adf0ce0e1d4),
+-- there was a case in QD-QEs distributed deployment that some QEs could skip full index scan and
+-- stop updating statistics, result in QD being unable to collect all QEs' stats thus overwrote
+-- a paritial accumulated value to index->reltuples. More interesting, it usually happened starting
+-- from the 3rd time of consecutively VACUUM after fresh inserts due to above skipping index scan
+-- criteria.
+-- 3rd VACUUM, expect reltuples = 2
+vacuum mytab3;
+select reltuples from pg_class where relname='mytab3';
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'mytab3_int_idx1';
+select reltuples from pg_class where relname='mytab3_int_idx1';
+
+drop table mytab;
+drop table mytab2;
+drop table mytab3;

--- a/src/test/regress/sql/uaocs_compaction/index_stats.sql
+++ b/src/test/regress/sql/uaocs_compaction/index_stats.sql
@@ -23,4 +23,83 @@ SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats';
 -- for reltuples to coordinate with the new behavior.
 -- start_ignore
 SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_idx1';
--- end_ignore
+
+-- Test to ensure that reltuples is updated for an index after lazy vacuum.
+-- This is vital as most index AMs that depend on this tuple count (eg btree, bitmap etc)
+-- which is passed up from the table AM during lazy vacuum.
+-- create a fresh table for the test
+CREATE TABLE uaocs_index_stats2(
+          col_int int,
+          col_text text,
+          col_numeric numeric,
+          col_unq int
+          ) with(appendonly=true, orientation=column) DISTRIBUTED BY (col_int);
+
+create index uaocs_index_stats2_int_idx1 on uaocs_index_stats2 using bitmap(col_int);
+
+insert into uaocs_index_stats2 values(1,'aa',1001,101),(2,'bb',1002,102);
+
+SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats2_int_idx1';
+
+-- first vacuum collect table stat on segments
+vacuum uaocs_index_stats2;
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'uaocs_index_stats2_int_idx1';
+-- second vacuum update index stat with table stat
+vacuum uaocs_index_stats2;
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'uaocs_index_stats2_int_idx1';
+SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats2_int_idx1';
+
+-- Test correctness of index->reltuples in consecutively VACUUM.
+CREATE TABLE uaocs_index_stats3(
+          col_int int,
+          col_text text,
+          col_numeric numeric,
+          col_unq int
+          ) with(appendonly=true, orientation=column) DISTRIBUTED BY (col_int);
+
+create index uaocs_index_stats3_int_idx1 on uaocs_index_stats3(col_int);
+
+insert into uaocs_index_stats3 values(1,'aa',1001,101),(2,'bb',1002,102);
+
+select reltuples from pg_class where relname='uaocs_index_stats3';
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'uaocs_index_stats3_int_idx1';
+select reltuples from pg_class where relname='uaocs_index_stats3_int_idx1';
+-- 1st VACUUM, expect reltuples = 2
+vacuum uaocs_index_stats3;
+select reltuples from pg_class where relname='uaocs_index_stats';
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'uaocs_index_stats3_int_idx1';
+select reltuples from pg_class where relname='uaocs_index_stats3_int_idx1';
+-- 2nd VACUUM, expect reltuples = 2
+vacuum uaocs_index_stats3;
+select reltuples from pg_class where relname='uaocs_index_stats3';
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'uaocs_index_stats3_int_idx1';
+select reltuples from pg_class where relname='uaocs_index_stats3_int_idx1';
+
+-- Prior to this fix, the case would be failed here. Given the
+-- scenario of updating stats during VACUUM:
+-- 1) coordinator vacuums and updates stats of its own;
+-- 2) then coordinator dispatches vacuum to segments;
+-- 3) coordinator combines stats received from segments to overwrite the stats of its own.
+-- Because upstream introduced a feature which could skip full index scan uring cleanup
+-- of B-tree indexes when possible (refer to:
+-- https://github.com/postgres/postgres/commit/857f9c36cda520030381bd8c2af20adf0ce0e1d4),
+-- there was a case in QD-QEs distributed deployment that some QEs could skip full index scan and
+-- stop updating statistics, result in QD being unable to collect all QEs' stats thus overwrote
+-- a paritial accumulated value to index->reltuples. More interesting, it usually happened starting
+-- from the 3rd time of consecutively VACUUM after fresh inserts due to above skipping index scan
+-- criteria.
+-- 3rd VACUUM, expect reltuples = 2
+vacuum uaocs_index_stats3;
+select reltuples from pg_class where relname='uaocs_index_stats3';
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'uaocs_index_stats3_int_idx1';
+select reltuples from pg_class where relname='uaocs_index_stats3_int_idx1';
+
+drop table uaocs_index_stats;
+drop table uaocs_index_stats2;
+drop table uaocs_index_stats3;


### PR DESCRIPTION
<!--Thank you for contributing!-->

<!--In case of an existing issue or discussions, please reference it-->
closes: #214
<!--Remove this section if no corresponding issue.-->

---

### Change logs
We enforce all QE to update stats after vacuum in the index, and all QD will collect stats and update the pg_class. Otherwises, only some QE will  update stats and send back to QD which left index stats in incomplete state.

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

no

### How was this patch tested?

cherrypick

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [x] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [x] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [x] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [x] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [x] Document changes.
- [x] Add tests for the change
- [x] Pass `make installcheck`
- [x] Pass `make -C src/test installcheck-cbdb-parallel`
- [x] Feel free to @cloudberrydb/dev team for review and approval when your PR is ready🥳
