### PR TITLE
New altertable rewrite dispatch policy

### DIFF
--- a/src/include/commands/tablecmds.h
+++ b/src/include/commands/tablecmds.h
@@ -20,6 +20,7 @@
 #include "catalog/gp_distribution_policy.h"
 #include "executor/executor.h"
 #include "executor/tuptable.h"
+#include "nodes/altertablenodes.h"
 #include "nodes/execnodes.h"
 #include "access/htup.h"
 #include "catalog/dependency.h"
@@ -132,5 +133,8 @@ extern void GpRenameChildPartitions(Relation targetrelation,
 									const char *oldparentrelname,
 									const char *newparentrelname);
 extern void set_random_distribution_if_drop_distkey(Relation rel, AttrNumber attnum);
+
+typedef void (*ATRewriteTable_hook_type)(AlteredTableInfo *tab, Oid OIDNewHeap, LOCKMODE lockmode);
+extern PGDLLIMPORT ATRewriteTable_hook_type ATRewriteTable_hook;
 
 #endif							/* TABLECMDS_H */


### PR DESCRIPTION
firstly add a hook to to let the QD to dispatch a new developed extensible message to QE for every table rewrite, the actual rewrite work will be done on QE. 

QD is not required to  dispatch a altertable statement at the end of ATcontroller