### PR TITLE
Limit CI concurrency to one per PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,11 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:    
       - main
-  
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }} # from https://stackoverflow.com/a/72408109/8711684
+  cancel-in-progress: true
+
 env:
   BUILD_TYPE: "debug"
   FTS_MODE: "internal_fts"


### PR DESCRIPTION
In current workflow, when newer commit comes, old pipeline won't get canceled, which wastes resources and cause unnecessary CI failure emails. This PR limits concurrency to one per PR. when newer commit comes, stale CI jobs will be automatically cancelled.

See: https://stackoverflow.com/a/72408109/8711684