### PR TITLE
Adjust the method of loading the external preloaded shared libraries

### DIFF
--- a/src/backend/utils/init/miscinit.c
+++ b/src/backend/utils/init/miscinit.c
@@ -1716,6 +1716,121 @@ char	   *local_preload_libraries_string = NULL;
 bool		process_shared_preload_libraries_in_progress = false;
 
 /*
+ * process shared preload libraries array.
+ */
+static const char *process_shared_preload_libraries_array[] =
+{
+	#include "utils/process_shared_preload_libraries.h"
+};
+
+/*
+ * remove duplicates list.
+ */
+static List*
+removeDuplicates(List* elemlist)
+{
+	List* unique_arr = NIL;
+	int i, j;
+	ListCell *l;
+	ListCell *l2;
+	for (i = 0; i < list_length(elemlist); i++)
+	{
+		bool found = false;
+		l = &elemlist->elements[i];
+		char* a = (char*)lfirst(l);
+		for (j = 0; j < list_length(unique_arr); j++)
+		{
+			l2 = &unique_arr->elements[j];
+			char* b = (char*)lfirst(l2);
+			if (strcmp(a, b) == 0)
+			{
+				found = true;
+				break;
+			}
+		}
+
+		if (!found)
+		{
+			unique_arr = lappend(unique_arr, pstrdup(a));
+		}
+	}
+	return unique_arr;
+}
+
+/*
+ * expand preload load libraries string.
+ */
+static char*
+expand_shared_preload_libraries_string()
+{
+	List	   *elemlist = NIL;
+	List	   *deduplicate_elemlist = NIL;
+	ListCell   *l;
+	char	   *rawstring;
+	char	   *libraries = shared_preload_libraries_string;
+
+	/* Need a modifiable copy of string */
+	rawstring = pstrdup(libraries);
+	if (libraries != NULL && libraries[0] != '\0')
+	{
+		/* Parse string into list of filename paths */
+		if (!SplitDirectoriesString(rawstring, ',', &elemlist))
+		{
+			/* syntax error in list */
+			list_free_deep(elemlist);
+			pfree(rawstring);
+			ereport(LOG,
+					(errcode(ERRCODE_SYNTAX_ERROR),
+					errmsg("invalid list syntax in parameter \"%s\"",
+							libraries)));
+			return NULL;
+		}
+
+	}
+
+	/* load expand libraries */
+	int shared_preload_libraries_num = sizeof(process_shared_preload_libraries_array) / sizeof(char *);
+	if (shared_preload_libraries_num > 0)
+	{
+		for (int i = 0; i < shared_preload_libraries_num; i++)
+		{
+			elemlist = lappend(elemlist, pstrdup((char*)process_shared_preload_libraries_array[i]));
+		}
+
+	}
+
+	if (list_length(elemlist) == 0)
+	{
+		list_free_deep(elemlist);
+		pfree(rawstring);
+		return NULL;
+	}
+
+
+	/* deduplicate list string */
+	if (list_length(elemlist) > 1)
+	{
+		deduplicate_elemlist = removeDuplicates(elemlist);
+	}
+
+	/* format string delimiter with ',' */
+	StringInfoData expand_string;
+	initStringInfo(&expand_string);
+	for (int i = 0; i < list_length(deduplicate_elemlist); i++)
+	{
+		l = &deduplicate_elemlist->elements[i];
+		if (i == 0)
+			appendStringInfo(&expand_string, "%s", (char*)lfirst(l));
+		else
+			appendStringInfo(&expand_string, ",%s", (char*)lfirst(l));
+	}
+	list_free_deep(elemlist);
+	list_free_deep(deduplicate_elemlist);
+	pfree(rawstring);
+	return expand_string.data;
+}
+
+/*
  * load the shared libraries listed in 'libraries'
  *
  * 'gucname': name of GUC variable, for error reports
@@ -1778,7 +1893,7 @@ process_shared_preload_libraries(void)
 {
 	process_shared_preload_libraries_in_progress = true;
 
-	load_libraries(shared_preload_libraries_string,
+	load_libraries(expand_shared_preload_libraries_string(),
 				   "shared_preload_libraries",
 				   false);
 

--- a/src/backend/utils/init/miscinit.c
+++ b/src/backend/utils/init/miscinit.c
@@ -1893,9 +1893,14 @@ process_shared_preload_libraries(void)
 {
 	process_shared_preload_libraries_in_progress = true;
 
-	load_libraries(expand_shared_preload_libraries_string(),
+	char* libraries = expand_shared_preload_libraries_string();
+	load_libraries(libraries,
 				   "shared_preload_libraries",
 				   false);
+	if (libraries != NULL)
+	{
+		pfree(libraries);
+	}
 
 #ifdef ENABLE_PRELOAD_IC_MODULE
 	load_libraries("interconnect",


### PR DESCRIPTION


<!--Thank you for contributing!-->

<!--In case of an existing issue or discussions, please reference it-->
closes: #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

Add a new mechanism to pre-load dynamic libraries during database startup. Controlled library inclusion through header files.

External lib is preloaded. Need to write to theprocess_shared_preload_libraries.h header file. This loads the external lib through the header file.

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to @cloudberrydb/dev team for review and approval when your PR is ready🥳
