### PR TITLE
Ignore cases related to external_fts

### DIFF
--- a/src/test/regress/expected/rpt_joins.out
+++ b/src/test/regress/expected/rpt_joins.out
@@ -2376,6 +2376,12 @@ explain(costs off) with cte1 as (insert into rpt_issue_15860 values (1, 2) retur
  Optimizer: Postgres query optimizer
 (10 rows)
 
+-- start_ignore
+-- When external_fts is on
+-- Seq scan on gp_segment_configuration would be replaced by 
+-- Function Scan on gp_get_segment_configuration 
+-- Inconsistence between CIs will cause such cases to fail.
+-- Ignore these as workaround.
 -- Replicate join Entry.
 explain(costs off) with cte1 as (insert into rpt_issue_15860 values (1, 2) returning *) select * from cte1 join gp_segment_configuration g on g.dbid = cte1.c1;
                           QUERY PLAN                           
@@ -2390,6 +2396,7 @@ explain(costs off) with cte1 as (insert into rpt_issue_15860 values (1, 2) retur
  Optimizer: Postgres query optimizer
 (8 rows)
 
+-- end_ignore
 --
 -- Begin of Replicated join Partitioned.
 --

--- a/src/test/regress/sql/rpt_joins.sql
+++ b/src/test/regress/sql/rpt_joins.sql
@@ -502,8 +502,15 @@ explain(costs off) with cte1 as (insert into rpt_issue_15860 values (1, 2) retur
 explain(costs off) with cte1 as (insert into rpt_issue_15860 values (1, 2) returning *) select * from cte1 right join (select count(*) as c from hash_issue_15860) a on a.c = cte1.c1;
 explain(costs off) with cte1 as (insert into rpt_issue_15860 values (1, 2) returning *) select * from cte1 full join (select count(*) as c from hash_issue_15860) a on a.c = cte1.c1;
 
+-- start_ignore
+-- When external_fts is on
+-- Seq scan on gp_segment_configuration would be replaced by 
+-- Function Scan on gp_get_segment_configuration 
+-- Inconsistence between CIs will cause such cases to fail.
+-- Ignore these as workaround.
 -- Replicate join Entry.
 explain(costs off) with cte1 as (insert into rpt_issue_15860 values (1, 2) returning *) select * from cte1 join gp_segment_configuration g on g.dbid = cte1.c1;
+-- end_ignore
 
 --
 -- Begin of Replicated join Partitioned.


### PR DESCRIPTION
Plan Seq scan on gp_segment_configuration would be replaced by Function Scan on gp_get_segment_configuration when external_fts is on.

Inconsistence between CIs will cause such cases to fail. Ignore these as workaround.

Authored-by: Zhang Mingli avamingli@gmail.com

<!--Thank you for contributing!-->

<!--In case of an existing issue or discussions, please reference it-->
closes: #246 
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to @cloudberrydb/dev team for review and approval when your PR is ready🥳
