### PR TITLE
Add motionhazard to the outer side of parallel aware join.(fix flaky incorrect results of agg)

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1127,6 +1127,7 @@ _copyHashJoin(const HashJoin *from)
 	COPY_NODE_FIELD(hashkeys);
 	COPY_NODE_FIELD(hashqualclauses);
 	COPY_SCALAR_FIELD(batch0_barrier);
+	COPY_SCALAR_FIELD(outer_motionhazard);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -864,6 +864,7 @@ _outHashJoin(StringInfo str, const HashJoin *node)
 	WRITE_NODE_FIELD(hashkeys);
 	WRITE_NODE_FIELD(hashqualclauses);
 	WRITE_BOOL_FIELD(batch0_barrier);
+	WRITE_BOOL_FIELD(outer_motionhazard);
 }
 
 static void

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2270,6 +2270,7 @@ _readHashJoin(void)
 	READ_NODE_FIELD(hashkeys);
 	READ_NODE_FIELD(hashqualclauses);
 	READ_BOOL_FIELD(batch0_barrier);
+	READ_BOOL_FIELD(outer_motionhazard);
 
 	READ_DONE();
 }

--- a/src/include/executor/hashjoin.h
+++ b/src/include/executor/hashjoin.h
@@ -287,6 +287,7 @@ typedef struct ParallelHashJoinState
 	Barrier		grow_buckets_barrier;
 	Barrier		sync_barrier;
 	Barrier		batch0_barrier;
+	Barrier		outer_motion_barrier;
 	volatile 	bool	phs_lasj_has_null; 	/* LASJ has found null value, identify early quit */
 	pg_atomic_uint32 distributor;	/* counter for load balancing */
 

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -1061,6 +1061,7 @@ typedef struct HashJoin
 	List	   *hashkeys;
 	List	   *hashqualclauses;
 	bool	    batch0_barrier;
+	bool	    outer_motionhazard; /* CBDB_PARALLEL: for parallel aware join */
 } HashJoin;
 
 #define SHARE_ID_NOT_SHARED (-1)

--- a/src/test/regress/expected/workfile/hashjoin_spill.out
+++ b/src/test/regress/expected/workfile/hashjoin_spill.out
@@ -40,10 +40,10 @@ insert into test_hj_spill SELECT i,i,i%1000,i,i,i,i,i from
 SET statement_mem=1024;
 set gp_resqueue_print_operator_memory_limits=on;
 set gp_workfile_compression = on;
-select avg(i3::numeric) from (SELECT t1.* FROM test_hj_spill AS t1 RIGHT JOIN test_hj_spill AS t2 ON t1.i1=t2.i2) foo;
-         avg          
-----------------------
- 499.5000000000000000
+select count(i3), avg(i3::numeric) from (SELECT t1.* FROM test_hj_spill AS t1 RIGHT JOIN test_hj_spill AS t2 ON t1.i1=t2.i2) foo;
+ count |         avg          
+-------+----------------------
+ 45000 | 499.5000000000000000
 (1 row)
 
 select * from hashjoin_spill.is_workfile_created('explain (analyze, verbose) SELECT t1.* FROM test_hj_spill AS t1 RIGHT JOIN test_hj_spill AS t2 ON t1.i1=t2.i2');
@@ -59,10 +59,10 @@ select * from hashjoin_spill.is_workfile_created('explain (analyze, verbose) SEL
 (1 row)
 
 set gp_workfile_compression = off;
-select avg(i3::numeric) from (SELECT t1.* FROM test_hj_spill AS t1 RIGHT JOIN test_hj_spill AS t2 ON t1.i1=t2.i2) foo;
-         avg          
-----------------------
- 499.5000000000000000
+select count(i3), avg(i3::numeric) from (SELECT t1.* FROM test_hj_spill AS t1 RIGHT JOIN test_hj_spill AS t2 ON t1.i1=t2.i2) foo;
+ count |         avg          
+-------+----------------------
+ 45000 | 499.5000000000000000
 (1 row)
 
 select * from hashjoin_spill.is_workfile_created('explain (analyze, verbose) SELECT t1.* FROM test_hj_spill AS t1 RIGHT JOIN test_hj_spill AS t2 ON t1.i1=t2.i2');

--- a/src/test/regress/sql/workfile/hashjoin_spill.sql
+++ b/src/test/regress/sql/workfile/hashjoin_spill.sql
@@ -44,12 +44,12 @@ SET statement_mem=1024;
 set gp_resqueue_print_operator_memory_limits=on;
 
 set gp_workfile_compression = on;
-select avg(i3::numeric) from (SELECT t1.* FROM test_hj_spill AS t1 RIGHT JOIN test_hj_spill AS t2 ON t1.i1=t2.i2) foo;
+select count(i3), avg(i3::numeric) from (SELECT t1.* FROM test_hj_spill AS t1 RIGHT JOIN test_hj_spill AS t2 ON t1.i1=t2.i2) foo;
 select * from hashjoin_spill.is_workfile_created('explain (analyze, verbose) SELECT t1.* FROM test_hj_spill AS t1 RIGHT JOIN test_hj_spill AS t2 ON t1.i1=t2.i2');
 select * from hashjoin_spill.is_workfile_created('explain (analyze, verbose) SELECT t1.* FROM test_hj_spill AS t1 RIGHT JOIN test_hj_spill AS t2 ON t1.i1=t2.i2 LIMIT 15000;');
 
 set gp_workfile_compression = off;
-select avg(i3::numeric) from (SELECT t1.* FROM test_hj_spill AS t1 RIGHT JOIN test_hj_spill AS t2 ON t1.i1=t2.i2) foo;
+select count(i3), avg(i3::numeric) from (SELECT t1.* FROM test_hj_spill AS t1 RIGHT JOIN test_hj_spill AS t2 ON t1.i1=t2.i2) foo;
 select * from hashjoin_spill.is_workfile_created('explain (analyze, verbose) SELECT t1.* FROM test_hj_spill AS t1 RIGHT JOIN test_hj_spill AS t2 ON t1.i1=t2.i2');
 select * from hashjoin_spill.is_workfile_created('explain (analyze, verbose) SELECT t1.* FROM test_hj_spill AS t1 RIGHT JOIN test_hj_spill AS t2 ON t1.i1=t2.i2 LIMIT 15000;');
 


### PR DESCRIPTION
For a parallel aware join, we may partition outer data to batches if there is not enough memory.And if a worker has consumed all the data from subnode, it will arrive and wait for others to begin next phase: PHJ_BUILD_DONE.

PHJ_BUILD_DONE means that we has partitioned every thing from PHJ_BUILD_HASHING_OUTER phase and are ready to probe. It's true for Postgres, becuase that if a worker pulls no data from subnode and it leaves PHJ_BUILD_HASHING_OUTER phase, all subnode's data must be processed(ex: a Parallel Seqscan).
As all participants leaves PHJ_BUILD_HASHING_OUTER, the whole data should be pulled completely by these processes, or there may be other siblings who have never participated in phase PHJ_BUILD_HASHING_OUTER at all.

But it's not true for CBDB, a plan node may have Motions behind. Some parallel workers pull no data from subnode, it doesn't mean that other workers have no data to process at all. We need to wait for all parallel workers together instead of build barrier's participants arrived at the current phase before we move to the next phase.

Add an outer_motion_barrier to ensure all parallel workers finish their work of partition outer batches.

Authored-by: Zhang Mingli avamingli@gmail.com

<!--Thank you for contributing!-->

<!--In case of an existing issue or discussions, please reference it-->
closes: #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to @cloudberrydb/dev team for review and approval when your PR is ready🥳
