### PR TITLE
Fix explain bad indent when showing operatorMem.

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -2083,9 +2083,7 @@ ExplainNode(PlanState *planstate, List *ancestors,
 	}
 
 	if (ResManagerPrintOperatorMemoryLimits())
-	{
-		ExplainPropertyInteger("operatorMem", "kB", PlanStateOperatorMemKB(planstate), es);
-	}
+		appendStringInfo(es->str, "  (operatorMem: "UINT64_FORMAT"kB)", PlanStateOperatorMemKB(planstate));
 	/*
 	 * We have to forcibly clean up the instrumentation state because we
 	 * haven't done ExecutorEnd yet.  This is pretty grotty ...

--- a/src/test/regress/expected/workfile/hashjoin_spill.out
+++ b/src/test/regress/expected/workfile/hashjoin_spill.out
@@ -39,6 +39,22 @@ insert into test_hj_spill SELECT i,i,i%1000,i,i,i,i,i from
 	(select count(*) as nsegments from gp_segment_configuration where role='p' and content >= 0) foo) bar;
 SET statement_mem=1024;
 set gp_resqueue_print_operator_memory_limits=on;
+explain(costs off) select count(i3), avg(i3::numeric) from (SELECT t1.* FROM test_hj_spill AS t1 RIGHT JOIN test_hj_spill AS t2 ON t1.i1=t2.i2) foo;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Finalize Aggregate  (operatorMem: 100kB)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (operatorMem: 100kB)
+         ->  Partial Aggregate  (operatorMem: 100kB)
+               ->  Hash Left Join  (operatorMem: 100kB)
+                     Hash Cond: (t2.i2 = t1.i1)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (operatorMem: 100kB)
+                           Hash Key: t2.i2
+                           ->  Seq Scan on test_hj_spill t2  (operatorMem: 100kB)
+                     ->  Hash  (operatorMem: 624kB)
+                           ->  Seq Scan on test_hj_spill t1  (operatorMem: 100kB)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
 set gp_workfile_compression = on;
 select count(i3), avg(i3::numeric) from (SELECT t1.* FROM test_hj_spill AS t1 RIGHT JOIN test_hj_spill AS t2 ON t1.i1=t2.i2) foo;
  count |         avg          

--- a/src/test/regress/sql/workfile/hashjoin_spill.sql
+++ b/src/test/regress/sql/workfile/hashjoin_spill.sql
@@ -42,6 +42,7 @@ insert into test_hj_spill SELECT i,i,i%1000,i,i,i,i,i from
 	(select count(*) as nsegments from gp_segment_configuration where role='p' and content >= 0) foo) bar;
 SET statement_mem=1024;
 set gp_resqueue_print_operator_memory_limits=on;
+explain(costs off) select count(i3), avg(i3::numeric) from (SELECT t1.* FROM test_hj_spill AS t1 RIGHT JOIN test_hj_spill AS t2 ON t1.i1=t2.i2) foo;
 
 set gp_workfile_compression = on;
 select count(i3), avg(i3::numeric) from (SELECT t1.* FROM test_hj_spill AS t1 RIGHT JOIN test_hj_spill AS t2 ON t1.i1=t2.i2) foo;


### PR DESCRIPTION
This is found by #284 during fix cases that require a resource limit option to reproduce when using resource queue.

Word operatorMem is added by GPDB, it shows bad indent when explain.
like `AggregateoperatorMem: 100 kB` 

```sql
set gp_resqueue_print_operator_memory_limits=on;
explain(costs off) select count(*) from test_hj_spill;
                                 QUERY PLAN
----------------------------------------------------------------------------
 Finalize AggregateoperatorMem: 100 kB

       ->  Gather Motion 3:1  (slice1; segments: 3)operatorMem: 100 kB

                 ->  Partial AggregateoperatorMem: 100 kB

                           ->  Seq Scan on test_hj_spilloperatorMem: 100 kB
```
This is introduced by UPSTREAM commit 1001368497 which tried to resolve explain indent of parallel query.

Add indent manually for CBDB's additional operatorMem.

Authored-by: Zhang Mingli avamingli@gmail.com

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [x] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [x] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [x] Add tests for the change
- [ ] Pass `make installcheck`
- [x] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
