### PR TITLE
Fix explain bad indent when showing operatorMem.

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -2083,9 +2083,7 @@ ExplainNode(PlanState *planstate, List *ancestors,
 	}
 
 	if (ResManagerPrintOperatorMemoryLimits())
-	{
-		ExplainPropertyInteger("operatorMem", "kB", PlanStateOperatorMemKB(planstate), es);
-	}
+		appendStringInfo(es->str, "  (operatorMem: "UINT64_FORMAT"kB)", PlanStateOperatorMemKB(planstate));
 	/*
 	 * We have to forcibly clean up the instrumentation state because we
 	 * haven't done ExecutorEnd yet.  This is pretty grotty ...

--- a/src/test/regress/expected/gp_aggregates_costs.out
+++ b/src/test/regress/expected/gp_aggregates_costs.out
@@ -111,3 +111,22 @@ explain (costs off) select b, sum(a) from t_planner_force_multi_stage group by b
 
 reset gp_eager_two_phase_agg;
 drop table t_planner_force_multi_stage;
+-- test operatorMem
+begin;
+create table test_operator_mem (i int, j int) distributed by (i);
+insert into test_operator_mem select i, i+1 from generate_series(1, 100)i;
+analyze test_operator_mem;
+set local statement_mem=1024;
+set local gp_resqueue_print_operator_memory_limits=on;
+explain(costs off)
+select count(*) from test_operator_mem;
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Finalize Aggregate  (operatorMem: 100kB)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (operatorMem: 100kB)
+         ->  Partial Aggregate  (operatorMem: 100kB)
+               ->  Seq Scan on test_operator_mem  (operatorMem: 100kB)
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+abort;

--- a/src/test/regress/expected/gp_aggregates_costs_optimizer.out
+++ b/src/test/regress/expected/gp_aggregates_costs_optimizer.out
@@ -111,3 +111,22 @@ explain (costs off) select b, sum(a) from t_planner_force_multi_stage group by b
 
 reset gp_eager_two_phase_agg;
 drop table t_planner_force_multi_stage;
+-- test operatorMem
+begin;
+create table test_operator_mem (i int, j int) distributed by (i);
+insert into test_operator_mem select i, i+1 from generate_series(1, 100)i;
+analyze test_operator_mem;
+set local statement_mem=1024;
+set local gp_resqueue_print_operator_memory_limits=on;
+explain(costs off)
+select count(*) from test_operator_mem;
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Finalize Aggregate  (operatorMem: 100kB)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (operatorMem: 100kB)
+         ->  Partial Aggregate  (operatorMem: 100kB)
+               ->  Seq Scan on test_operator_mem  (operatorMem: 100kB)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+abort;

--- a/src/test/regress/sql/gp_aggregates_costs.sql
+++ b/src/test/regress/sql/gp_aggregates_costs.sql
@@ -47,3 +47,15 @@ set gp_eager_two_phase_agg = on;
 explain (costs off) select b, sum(a) from t_planner_force_multi_stage group by b;
 reset gp_eager_two_phase_agg;
 drop table t_planner_force_multi_stage;
+
+-- test operatorMem
+begin;
+create table test_operator_mem (i int, j int) distributed by (i);
+insert into test_operator_mem select i, i+1 from generate_series(1, 100)i;
+analyze test_operator_mem;
+set local statement_mem=1024;
+set local gp_resqueue_print_operator_memory_limits=on;
+explain(costs off)
+select count(*) from test_operator_mem;
+
+abort;


### PR DESCRIPTION
Word operatorMem is added by GPDB, it shows bad indent when explain.

```sql
set gp_resqueue_print_operator_memory_limits=on;
explain(costs off) select count(*) from test_hj_spill;
                                 QUERY PLAN
----------------------------------------------------------------------------
 Finalize AggregateoperatorMem: 100 kB

       ->  Gather Motion 3:1  (slice1; segments: 3)operatorMem: 100 kB

                 ->  Partial AggregateoperatorMem: 100 kB

                           ->  Seq Scan on test_hj_spilloperatorMem: 100 kB
```

This is introduced by UPSTREAM commit 1001368497 which tried to resolve explain indent of parallel query.

Add indent manually for CBDB's additional operatorMem.

Authored-by: Zhang Mingli avamingli@gmail.com

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
