### PR TITLE
Fix: enable trigger throught FDW in the serverless architecture.

### DIFF
--- a/src/backend/access/table/table.c
+++ b/src/backend/access/table/table.c
@@ -226,7 +226,13 @@ CdbTryOpenTable(Oid relid, LOCKMODE reqmode, bool *lockUpgraded)
 		{
 			lockmode = RowExclusiveLock;
 			rel = try_table_open(relid, lockmode, false);
-			if (RelationIsAppendOptimized(rel))
+			/*
+			 * FIXME: table which is not a heap table and AO table
+			 * does not support concurrently update or delete. So
+			 * we upgrade lockmode as the same as AO|AOCO.
+			 */
+			if (RelationIsAppendOptimized(rel) ||
+				(enable_serverless && (!RelationIsHeap(rel) && !RelationIsAppendOptimized(rel))))
 			{
 				/*
 				 * AO|AOCO table does not support concurrently


### PR DESCRIPTION
In serverless architecture, implementing trigger the same as foreign table which use tuplestore to store the tuple is more efficient. Because it is inefficient to fetch tuple throught its ctid. Besides, in serverless architecture, concurrent update or delete is not supported. So we can fetch tuple directly without lock tuple in GetTupleForTrigger.

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
