### PR TITLE
Fix: disable isolation level XACT_REPEATABLE_READ

### DIFF
--- a/src/backend/commands/variable.c
+++ b/src/backend/commands/variable.c
@@ -527,6 +527,17 @@ check_XactIsoLevel(int *newval, void **extra, GucSource source)
 {
 	int			newXactIsoLevel = *newval;
 
+	/*
+	 * FIXME: we cannot support XACT_REPEATABLE_READ now due to concurrent 
+	 * insert. In concurrent insert, one transaction apply new change based
+	 * on the result of other transaction done. Thus, XACT_REPEATABLE_READ
+	 * is not support and will be support soon.
+	 */
+	if(enable_serverless && newXactIsoLevel == XACT_REPEATABLE_READ){
+		GUC_check_errcode(ERRCODE_ACTIVE_SQL_TRANSACTION);
+		GUC_check_errmsg("XACT_REPEATABLE_READ is not support now");	
+	}
+
 	if (newXactIsoLevel != XactIsoLevel && IsTransactionState())
 	{
 		if (FirstSnapshotSet)


### PR DESCRIPTION
in the serverless architecture.

In the serverless architecture, we cannot support XACT_REPEATABLE_READ now due to concurrent insert. In concurrent insert, one transaction apply new change based on the result of other transaction done. Thus, XACT_REPEATABLE_READ is not support and will be support soon.

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
