### PR TITLE
[Answer Query Using Materialized Views] Compute Aggregations on Materialized Views.

### DIFF
--- a/src/backend/optimizer/README.cbdb.aqumv
+++ b/src/backend/optimizer/README.cbdb.aqumv
@@ -220,7 +220,7 @@ AQUMV_MVP
 ---------
 Support SELECT FROM a single relation both for mv_query and the origin_query.
 Below are not supported now:
-      AGG
+      Aggregation (on mv_query)
       Subquery
       Order by(for origin_query)
       Join

--- a/src/test/regress/expected/aqumv.out
+++ b/src/test/regress/expected/aqumv.out
@@ -732,6 +732,260 @@ select sqrt(abs(abs(c2) - c1 - 1) + abs(c2)) from aqumv_t1 where c1 > 30 and c1 
 (7 rows)
 
 abort;
+--
+-- Support origin query with aggregations.
+-- Compute Aggregations from mv.
+--
+begin;
+create table aqumv_t2(c1 int, c2 int, c3 int) distributed by (c1);
+insert into aqumv_t2 select i, i+1, i+2 from generate_series(1, 100) i;
+insert into aqumv_t2 values (91, NULL, 95);
+analyze aqumv_t2;
+create incremental materialized view aqumv_mvt2_0 as
+  select c1 as mc1, c2 as mc2, c3 as mc3
+  from aqumv_t2 where c1 > 90;
+analyze aqumv_mvt2_0;
+-- test aggregation functions supported in IVM. 
+set local enable_answer_query_using_materialized_views = off;
+explain(costs off, verbose)
+select count(c1), sum(c2), avg(c3) from aqumv_t2 where c1 > 90;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(c1), sum(c2), avg(c3)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(c1)), (PARTIAL sum(c2)), (PARTIAL avg(c3))
+         ->  Partial Aggregate
+               Output: PARTIAL count(c1), PARTIAL sum(c2), PARTIAL avg(c3)
+               ->  Seq Scan on public.aqumv_t2
+                     Output: c1, c2, c3
+                     Filter: (aqumv_t2.c1 > 90)
+ Settings: enable_answer_query_using_materialized_views = 'off', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select count(c1), sum(c2), avg(c3) from aqumv_t2 where c1 > 90;
+ count | sum |         avg         
+-------+-----+---------------------
+    11 | 965 | 97.2727272727272727
+(1 row)
+
+set local enable_answer_query_using_materialized_views = on;
+explain(costs off, verbose)
+select count(c1), sum(c2), avg(c3) from aqumv_t2 where c1 > 90;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(mc1), sum(mc2), avg(mc3)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(mc1)), (PARTIAL sum(mc2)), (PARTIAL avg(mc3))
+         ->  Partial Aggregate
+               Output: PARTIAL count(mc1), PARTIAL sum(mc2), PARTIAL avg(mc3)
+               ->  Seq Scan on public.aqumv_mvt2_0
+                     Output: mc1, mc2, mc3
+ Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select count(c1), sum(c2), avg(c3) from aqumv_t2 where c1 > 90;
+ count | sum |         avg         
+-------+-----+---------------------
+    11 | 965 | 97.2727272727272727
+(1 row)
+
+-- test complex expressions have AGG.
+set local enable_answer_query_using_materialized_views = off;
+explain(costs off, verbose)
+select count(c1) + 1 from aqumv_t2 where c1 > 90;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: (count(c1) + 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(c1))
+         ->  Partial Aggregate
+               Output: PARTIAL count(c1)
+               ->  Seq Scan on public.aqumv_t2
+                     Output: c1, c2, c3
+                     Filter: (aqumv_t2.c1 > 90)
+ Settings: enable_answer_query_using_materialized_views = 'off', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select count(c1) + 1 from aqumv_t2 where c1 > 90;
+ ?column? 
+----------
+       12
+(1 row)
+
+set local enable_answer_query_using_materialized_views = on;
+explain(costs off, verbose)
+select count(c1) + 1 from aqumv_t2 where c1 > 90;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: (count(mc1) + 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(mc1))
+         ->  Partial Aggregate
+               Output: PARTIAL count(mc1)
+               ->  Seq Scan on public.aqumv_mvt2_0
+                     Output: mc1, mc2, mc3
+ Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select count(c1) + 1 from aqumv_t2 where c1 > 90;
+ ?column? 
+----------
+       12
+(1 row)
+
+-- test AGG FILTER.
+set local enable_answer_query_using_materialized_views = off;
+explain(costs off, verbose)
+select sum(c2), sum(c2) filter (where c2 > 95) from aqumv_t2 where c1 > 90;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(c2), sum(c2) FILTER (WHERE (c2 > 95))
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL sum(c2)), (PARTIAL sum(c2) FILTER (WHERE (c2 > 95)))
+         ->  Partial Aggregate
+               Output: PARTIAL sum(c2), PARTIAL sum(c2) FILTER (WHERE (c2 > 95))
+               ->  Seq Scan on public.aqumv_t2
+                     Output: c1, c2, c3
+                     Filter: (aqumv_t2.c1 > 90)
+ Settings: enable_answer_query_using_materialized_views = 'off', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select sum(c2), sum(c2) filter (where c2 > 95) from aqumv_t2 where c1 > 90;
+ sum | sum 
+-----+-----
+ 965 | 591
+(1 row)
+
+set local enable_answer_query_using_materialized_views = on;
+explain(costs off, verbose)
+select sum(c2), sum(c2) filter (where c2 > 95) from aqumv_t2 where c1 > 90;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(mc2), sum(mc2) FILTER (WHERE (mc2 > 95))
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL sum(mc2)), (PARTIAL sum(mc2) FILTER (WHERE (mc2 > 95)))
+         ->  Partial Aggregate
+               Output: PARTIAL sum(mc2), PARTIAL sum(mc2) FILTER (WHERE (mc2 > 95))
+               ->  Seq Scan on public.aqumv_mvt2_0
+                     Output: mc1, mc2, mc3
+ Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select sum(c2), sum(c2) filter (where c2 > 95) from aqumv_t2 where c1 > 90;
+ sum | sum 
+-----+-----
+ 965 | 591
+(1 row)
+
+-- test AGG functions which are not supported in IVM now, but could work in AQUMV. 
+set local enable_answer_query_using_materialized_views = off;
+explain(costs off, verbose)
+select max(c1), min(c3), stddev(c2) from aqumv_t2 where c1 > 90;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: max(c1), min(c3), stddev(c2)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL max(c1)), (PARTIAL min(c3)), (PARTIAL stddev(c2))
+         ->  Partial Aggregate
+               Output: PARTIAL max(c1), PARTIAL min(c3), PARTIAL stddev(c2)
+               ->  Seq Scan on public.aqumv_t2
+                     Output: c1, c2, c3
+                     Filter: (aqumv_t2.c1 > 90)
+ Settings: enable_answer_query_using_materialized_views = 'off', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select max(c1), min(c3), stddev(c2) from aqumv_t2 where c1 > 90;
+ max | min |       stddev       
+-----+-----+--------------------
+ 100 |  93 | 3.0276503540974917
+(1 row)
+
+set local enable_answer_query_using_materialized_views = on;
+explain(costs off, verbose)
+select max(c1), min(c3), stddev(c2) from aqumv_t2 where c1 > 90;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: max(mc1), min(mc3), stddev(mc2)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL max(mc1)), (PARTIAL min(mc3)), (PARTIAL stddev(mc2))
+         ->  Partial Aggregate
+               Output: PARTIAL max(mc1), PARTIAL min(mc3), PARTIAL stddev(mc2)
+               ->  Seq Scan on public.aqumv_mvt2_0
+                     Output: mc1, mc2, mc3
+ Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select max(c1), min(c3), stddev(c2) from aqumv_t2 where c1 > 90;
+ max | min |       stddev       
+-----+-----+--------------------
+ 100 |  93 | 3.0276503540974917
+(1 row)
+
+-- test count(*)
+set local enable_answer_query_using_materialized_views = off;
+explain(costs off, verbose)
+select count(c2), count(*) from aqumv_t2 where c1 > 90;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(c2), count(*)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(c2)), (PARTIAL count(*))
+         ->  Partial Aggregate
+               Output: PARTIAL count(c2), PARTIAL count(*)
+               ->  Seq Scan on public.aqumv_t2
+                     Output: c1, c2, c3
+                     Filter: (aqumv_t2.c1 > 90)
+ Settings: enable_answer_query_using_materialized_views = 'off', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select count(c2), count(*) from aqumv_t2 where c1 > 90;
+ count | count 
+-------+-------
+    10 |    11
+(1 row)
+
+set local enable_answer_query_using_materialized_views = on;
+explain(costs off, verbose)
+select count(c2), count(*) from aqumv_t2 where c1 > 90;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(mc2), count(*)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(mc2)), (PARTIAL count(*))
+         ->  Partial Aggregate
+               Output: PARTIAL count(mc2), PARTIAL count(*)
+               ->  Seq Scan on public.aqumv_mvt2_0
+                     Output: mc1, mc2, mc3
+ Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select count(c2), count(*) from aqumv_t2 where c1 > 90;
+ count | count 
+-------+-------
+    10 |    11
+(1 row)
+
+abort;
 reset optimizer;
 reset enable_answer_query_using_materialized_views;
 drop table aqumv_t1 cascade;


### PR DESCRIPTION
Support origin query has aggregations, compute Aggregations on materilized views whose query don't have Aggegations itself.
```sql
create incremental materialized view mv as
  select c1 as mc1, c2 as mc2, c3 as mc3 from t1 where c1 > 90;
```
Origin query:
```sql
select count(c1)+1, sum(c2) filter (where c2 > 95), stddev(c3) from t1 where c1 > 90;
```
Could be rewritten to:
```sql
select count(mc1)+1, sum(mc2) filter (where mc2 > 95), stddev(mc3) from mv;
```
All aggregate functions including count(*) are supported in AQUMV which is not limited to IVM's current aggregate functions: count, sum, avg.
Complex expressions have aggregations, and aggregations with Filter clause are also supported.

**Aggs in TargetList**
aqumv_process_targetlist() could handle that because all Vars under Aggrefs could be  rewritten to mv's columns. 
Complex expression have Aggs could be processed as we use a Greedy Algorithem to match target expressions.

**Aggs Filter Clause**
They could be processed automatically as we process post_quals in aqumv_adjust_sub_matched_expr_mutator().

**Count(*)**
Expressin count(*) has no explicit Vars, but it still need rows from subplan nodes.
NULL values should be taken into account unlike count(a_column).

--------

An example with AGG FILTER clause(**See more details in test cases.**)

```sql
explain(costs off, verbose)
select sum(c2), sum(c2) filter (where c2 > 95) from aqumv_t2 where c1 > 90;
                                    QUERY PLAN                                     
-----------------------------------------------------------------------------------
 Finalize Aggregate
   Output: sum(c2), sum(c2) FILTER (WHERE (c2 > 95))
   ->  Gather Motion 3:1  (slice1; segments: 3)
         Output: (PARTIAL sum(c2)), (PARTIAL sum(c2) FILTER (WHERE (c2 > 95)))
         ->  Partial Aggregate
               Output: PARTIAL sum(c2), PARTIAL sum(c2) FILTER (WHERE (c2 > 95))
               ->  Seq Scan on public.aqumv_t2
                     Output: c1, c2, c3
                     Filter: (aqumv_t2.c1 > 90)
 Settings: enable_answer_query_using_materialized_views = 'off', optimizer = 'off'
 Optimizer: Postgres query optimizer
(11 rows)

select sum(c2), sum(c2) filter (where c2 > 95) from aqumv_t2 where c1 > 90;
 sum | sum 
-----+-----
 965 | 591
(1 row)
```
**Compute Aggregations on Materialized Views**
```sql
set enable_answer_query_using_materialized_views = on;
explain(costs off, verbose)
select sum(c2), sum(c2) filter (where c2 > 95) from aqumv_t2 where c1 > 90;
                                     QUERY PLAN                                     
------------------------------------------------------------------------------------
 Finalize Aggregate
   Output: sum(mc2), sum(mc2) FILTER (WHERE (mc2 > 95))
   ->  Gather Motion 3:1  (slice1; segments: 3)
         Output: (PARTIAL sum(mc2)), (PARTIAL sum(mc2) FILTER (WHERE (mc2 > 95)))
         ->  Partial Aggregate
               Output: PARTIAL sum(mc2), PARTIAL sum(mc2) FILTER (WHERE (mc2 > 95))
               ->  Seq Scan on public.aqumv_mvt2_0
                     Output: mc1, mc2, mc3
 Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
 Optimizer: Postgres query optimizer
(10 rows)

select sum(c2), sum(c2) filter (where c2 > 95) from aqumv_t2 where c1 > 90;
 sum | sum 
-----+-----
 965 | 591
(1 row)
```



Authored-by: Zhang Mingli avamingli@gmail.com

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [x] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [x] Add tests for the change
- [x] Pass `make installcheck`
- [x] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
