### PR TITLE
Fix: may cause UAF problem in get_size_from_segDBs

### DIFF
--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -89,21 +89,30 @@ get_size_from_segDBs(const char *cmd)
 	for (i = 0; i < cdb_pgresults.numResults; i++)
 	{
 		Datum		value;
+		ExecStatusType status;
+		int ntuples;
+		int nfields;
+
 		struct pg_result *pgresult = cdb_pgresults.pg_results[i];
 
-		if (PQresultStatus(pgresult) != PGRES_TUPLES_OK)
+		status = PQresultStatus(pgresult);
+		if (status != PGRES_TUPLES_OK)
 		{
 			cdbdisp_clearCdbPgResults(&cdb_pgresults);
 			ereport(ERROR,
 					(errmsg("unexpected result from segment: %d",
-							PQresultStatus(pgresult))));
+							status)));
 		}
-		if (PQntuples(pgresult) != 1 || PQnfields(pgresult) != 1)
+
+		ntuples = PQntuples(pgresult);
+		nfields = PQnfields(pgresult);
+
+		if (ntuples != 1 || nfields != 1)
 		{
 			cdbdisp_clearCdbPgResults(&cdb_pgresults);
 			ereport(ERROR,
 					(errmsg("unexpected shape of result from segment (%d rows, %d cols)",
-							PQntuples(pgresult), PQnfields(pgresult))));
+							ntuples, nfields)));
 		}
 		if (PQgetisnull(pgresult, 0, 0))
 			value = 0;


### PR DESCRIPTION
<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #NO_ISSUE_NUMBER
<!--Remove this section if no corresponding issue.-->


### Change logs

nope

### Why are the changes needed?

In function `get_size_from_segDBs`, If the cdb result returned from segment is not as expected. Then we will clear up the cdb call the ereport. But in this cause the value in cdb result have been freed. We should keep a cdb result before cleanup it.

### Does this PR introduce any user-facing change?

nope

### How was this patch tested?

nope

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
