### PR TITLE
Fix \\d in psql to show correct storage name from pg_am

### DIFF
--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -4983,7 +4983,6 @@ listTables(const char *tabtypes, const char *pattern, bool verbose, bool showSys
 					  " WHEN " CppAsString2(RELKIND_MATVIEW) " THEN '%s'"
 					  " WHEN " CppAsString2(RELKIND_INDEX) " THEN '%s'"
 					  " WHEN " CppAsString2(RELKIND_SEQUENCE) " THEN '%s'"
-					  " WHEN 's' THEN '%s'"
 					  " WHEN " CppAsString2(RELKIND_TOASTVALUE) " THEN '%s'"
 					  " WHEN " CppAsString2(RELKIND_FOREIGN_TABLE) " THEN '%s'"
 					  " WHEN " CppAsString2(RELKIND_PARTITIONED_TABLE) " THEN '%s'"
@@ -4997,7 +4996,6 @@ listTables(const char *tabtypes, const char *pattern, bool verbose, bool showSys
 					  gettext_noop("materialized view"),
 					  gettext_noop("index"),
 					  gettext_noop("sequence"),
-					  gettext_noop("special"),
 					  gettext_noop("TOAST table"),
 					  gettext_noop("foreign table"),
 					  gettext_noop("partitioned table"),
@@ -5012,10 +5010,10 @@ listTables(const char *tabtypes, const char *pattern, bool verbose, bool showSys
 		if (isGPDB7000OrLater())
 		{
 			appendPQExpBuffer(&buf, ", CASE c.relam");
-			appendPQExpBuffer(&buf, " WHEN %d THEN '%s'", HEAP_TABLE_AM_OID, gettext_noop("heap"));
 			appendPQExpBuffer(&buf, " WHEN %d THEN '%s'", AO_ROW_TABLE_AM_OID, gettext_noop("append only"));
 			appendPQExpBuffer(&buf, " WHEN %d THEN '%s'", AO_COLUMN_TABLE_AM_OID, gettext_noop("append only columnar"));
-			appendPQExpBuffer(&buf, " WHEN %d THEN '%s'", BTREE_AM_OID, gettext_noop("btree"));
+			appendPQExpBuffer(&buf, " ELSE (SELECT amname FROM pg_am WHERE pg_am.oid=c.relam)");
+
 			appendPQExpBuffer(&buf, " END as \"%s\"\n", gettext_noop("Storage"));
 		}
 		else

--- a/src/test/regress/expected/psql.out
+++ b/src/test/regress/expected/psql.out
@@ -2866,21 +2866,21 @@ Access method: heap
 
 -- AM is displayed for tables, indexes and materialized views.
 \d+
-                                                                List of relations
-     Schema      |        Name        |       Type        |        Owner         | Storage | Persistence | Access method |  Size   | Description 
------------------+--------------------+-------------------+----------------------+---------+-------------+---------------+---------+-------------
- tableam_display | mat_view_heap_psql | materialized view | regress_display_role |         | permanent   | heap_psql     | 0 bytes | 
- tableam_display | tbl_heap           | table             | regress_display_role | heap    | permanent   | heap          | 0 bytes | 
- tableam_display | tbl_heap_psql      | table             | regress_display_role |         | permanent   | heap_psql     | 0 bytes | 
- tableam_display | view_heap_psql     | view              | regress_display_role |         | permanent   |               | 0 bytes | 
+                                                                 List of relations
+     Schema      |        Name        |       Type        |        Owner         |  Storage  | Persistence | Access method |  Size   | Description 
+-----------------+--------------------+-------------------+----------------------+-----------+-------------+---------------+---------+-------------
+ tableam_display | mat_view_heap_psql | materialized view | regress_display_role | heap_psql | permanent   | heap_psql     | 0 bytes | 
+ tableam_display | tbl_heap           | table             | regress_display_role | heap      | permanent   | heap          | 0 bytes | 
+ tableam_display | tbl_heap_psql      | table             | regress_display_role | heap_psql | permanent   | heap_psql     | 0 bytes | 
+ tableam_display | view_heap_psql     | view              | regress_display_role |           | permanent   |               | 0 bytes | 
 (4 rows)
 
 \dt+
-                                                       List of relations
-     Schema      |     Name      | Type  |        Owner         | Storage | Persistence | Access method |  Size   | Description 
------------------+---------------+-------+----------------------+---------+-------------+---------------+---------+-------------
- tableam_display | tbl_heap      | table | regress_display_role | heap    | permanent   | heap          | 0 bytes | 
- tableam_display | tbl_heap_psql | table | regress_display_role |         | permanent   | heap_psql     | 0 bytes | 
+                                                        List of relations
+     Schema      |     Name      | Type  |        Owner         |  Storage  | Persistence | Access method |  Size   | Description 
+-----------------+---------------+-------+----------------------+-----------+-------------+---------------+---------+-------------
+ tableam_display | tbl_heap      | table | regress_display_role | heap      | permanent   | heap          | 0 bytes | 
+ tableam_display | tbl_heap_psql | table | regress_display_role | heap_psql | permanent   | heap_psql     | 0 bytes | 
 (2 rows)
 
 \dm+
@@ -2900,13 +2900,13 @@ Access method: heap
 
 \set HIDE_TABLEAM on
 \d+
-                                                        List of relations
-     Schema      |        Name        |       Type        |        Owner         | Storage | Persistence |  Size   | Description 
------------------+--------------------+-------------------+----------------------+---------+-------------+---------+-------------
- tableam_display | mat_view_heap_psql | materialized view | regress_display_role |         | permanent   | 0 bytes | 
- tableam_display | tbl_heap           | table             | regress_display_role | heap    | permanent   | 0 bytes | 
- tableam_display | tbl_heap_psql      | table             | regress_display_role |         | permanent   | 0 bytes | 
- tableam_display | view_heap_psql     | view              | regress_display_role |         | permanent   | 0 bytes | 
+                                                         List of relations
+     Schema      |        Name        |       Type        |        Owner         |  Storage  | Persistence |  Size   | Description 
+-----------------+--------------------+-------------------+----------------------+-----------+-------------+---------+-------------
+ tableam_display | mat_view_heap_psql | materialized view | regress_display_role | heap_psql | permanent   | 0 bytes | 
+ tableam_display | tbl_heap           | table             | regress_display_role | heap      | permanent   | 0 bytes | 
+ tableam_display | tbl_heap_psql      | table             | regress_display_role | heap_psql | permanent   | 0 bytes | 
+ tableam_display | view_heap_psql     | view              | regress_display_role |           | permanent   | 0 bytes | 
 (4 rows)
 
 RESET ROLE;

--- a/src/test/singlenode_regress/expected/psql.out
+++ b/src/test/singlenode_regress/expected/psql.out
@@ -2866,21 +2866,21 @@ Access method: heap
 
 -- AM is displayed for tables, indexes and materialized views.
 \d+
-                                                                List of relations
-     Schema      |        Name        |       Type        |        Owner         | Storage | Persistence | Access method |  Size   | Description 
------------------+--------------------+-------------------+----------------------+---------+-------------+---------------+---------+-------------
- tableam_display | mat_view_heap_psql | materialized view | regress_display_role |         | permanent   | heap_psql     | 0 bytes | 
- tableam_display | tbl_heap           | table             | regress_display_role | heap    | permanent   | heap          | 0 bytes | 
- tableam_display | tbl_heap_psql      | table             | regress_display_role |         | permanent   | heap_psql     | 0 bytes | 
- tableam_display | view_heap_psql     | view              | regress_display_role |         | permanent   |               | 0 bytes | 
+                                                                 List of relations
+     Schema      |        Name        |       Type        |        Owner         |  Storage  | Persistence | Access method |  Size   | Description 
+-----------------+--------------------+-------------------+----------------------+-----------+-------------+---------------+---------+-------------
+ tableam_display | mat_view_heap_psql | materialized view | regress_display_role | heap_psql | permanent   | heap_psql     | 0 bytes | 
+ tableam_display | tbl_heap           | table             | regress_display_role | heap      | permanent   | heap          | 0 bytes | 
+ tableam_display | tbl_heap_psql      | table             | regress_display_role | heap_psql | permanent   | heap_psql     | 0 bytes | 
+ tableam_display | view_heap_psql     | view              | regress_display_role |           | permanent   |               | 0 bytes | 
 (4 rows)
 
 \dt+
-                                                       List of relations
-     Schema      |     Name      | Type  |        Owner         | Storage | Persistence | Access method |  Size   | Description 
------------------+---------------+-------+----------------------+---------+-------------+---------------+---------+-------------
- tableam_display | tbl_heap      | table | regress_display_role | heap    | permanent   | heap          | 0 bytes | 
- tableam_display | tbl_heap_psql | table | regress_display_role |         | permanent   | heap_psql     | 0 bytes | 
+                                                        List of relations
+     Schema      |     Name      | Type  |        Owner         |  Storage  | Persistence | Access method |  Size   | Description 
+-----------------+---------------+-------+----------------------+-----------+-------------+---------------+---------+-------------
+ tableam_display | tbl_heap      | table | regress_display_role | heap      | permanent   | heap          | 0 bytes | 
+ tableam_display | tbl_heap_psql | table | regress_display_role | heap_psql | permanent   | heap_psql     | 0 bytes | 
 (2 rows)
 
 \dm+
@@ -2900,13 +2900,13 @@ Access method: heap
 
 \set HIDE_TABLEAM on
 \d+
-                                                        List of relations
-     Schema      |        Name        |       Type        |        Owner         | Storage | Persistence |  Size   | Description 
------------------+--------------------+-------------------+----------------------+---------+-------------+---------+-------------
- tableam_display | mat_view_heap_psql | materialized view | regress_display_role |         | permanent   | 0 bytes | 
- tableam_display | tbl_heap           | table             | regress_display_role | heap    | permanent   | 0 bytes | 
- tableam_display | tbl_heap_psql      | table             | regress_display_role |         | permanent   | 0 bytes | 
- tableam_display | view_heap_psql     | view              | regress_display_role |         | permanent   | 0 bytes | 
+                                                         List of relations
+     Schema      |        Name        |       Type        |        Owner         |  Storage  | Persistence |  Size   | Description 
+-----------------+--------------------+-------------------+----------------------+-----------+-------------+---------+-------------
+ tableam_display | mat_view_heap_psql | materialized view | regress_display_role | heap_psql | permanent   | 0 bytes | 
+ tableam_display | tbl_heap           | table             | regress_display_role | heap      | permanent   | 0 bytes | 
+ tableam_display | tbl_heap_psql      | table             | regress_display_role | heap_psql | permanent   | 0 bytes | 
+ tableam_display | view_heap_psql     | view              | regress_display_role |           | permanent   | 0 bytes | 
 (4 rows)
 
 RESET ROLE;


### PR DESCRIPTION
Standard am name is determined from the catalog pg_am, except ao-row/ao-column tables. Use a select query to replace the hard-coded amname.


Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
