### PR TITLE
Move struct workfile_set to workfile_mgr.c

### DIFF
--- a/src/include/utils/workfile_mgr.h
+++ b/src/include/utils/workfile_mgr.h
@@ -53,41 +53,8 @@ typedef struct WorkFileUsagePerQuery
 
 } WorkFileUsagePerQuery;
 
-typedef struct workfile_set
-{
-	/* Session id for the query creating the workfile set */
-	int			session_id;
-
-	/* Command count for the query creating the workfile set */
-	int			command_count;
-
-	/* Number of files in set */
-	uint32		num_files;
-
-	/* Size in bytes of the files in this workfile set */
-	int64		total_bytes;
-
-	/* Prefix of files in the workfile set */
-	char		prefix[WORKFILE_PREFIX_LEN];
-
-	/* Type of operator creating the workfile set */
-	char		operator[NAMEDATALEN];
-
-	/* Slice in which the spilling operator was */
-	int			slice_id;
-
-	WorkFileUsagePerQuery *perquery;
-
-	dlist_node	node;
-
-	bool		active;
-
-	/* If the workfile is pinned, don't free it unless call workfile_mgr_close_set */
-	bool		pinned;
-
-	/* Used to track workfile_set created in current process */
-	dlist_node	local_node;
-} workfile_set;
+struct workfile_set;
+typedef struct workfile_set workfile_set;
 
 /* Workfile Set operations */
 
@@ -105,5 +72,6 @@ extern void workfile_mgr_close_set(workfile_set *work_set);
 extern Datum gp_workfile_mgr_cache_entries_internal(PG_FUNCTION_ARGS);
 extern workfile_set *workfile_mgr_cache_entries_get_copy(int* num_actives);
 extern uint64 WorkfileSegspace_GetSize(void);
+extern bool workfile_is_active(workfile_set *workfile);
 
 #endif /* __WORKFILE_MGR_H__ */

--- a/src/test/isolation2/workfile_mgr_test.c
+++ b/src/test/isolation2/workfile_mgr_test.c
@@ -145,7 +145,7 @@ gp_workfile_mgr_create_workset(PG_FUNCTION_ARGS)
 	BufFile *buffile;
 
 	workfile_set *work_set = workfile_mgr_create_set(worksetName, NULL, holdPin);
-	Assert(work_set->active);
+	Assert(workfile_is_active(work_set));
 
 	if (!emptySet)
 	{
@@ -674,7 +674,7 @@ workfile_create_and_set_cleanup(void)
 	elog(LOG, "Running sub-test: Closing Workset");
 	workfile_mgr_close_set(work_set);
 
-	unit_test_result(!work_set->active);
+	unit_test_result(!workfile_is_active(work_set));
 
 	return unit_test_summary();
 }
@@ -719,7 +719,7 @@ workfile_made_in_temp_tablespace(void)
 
 	BufFileClose(bufFile);
 
-	unit_test_result(!work_set->active);
+	unit_test_result(!workfile_is_active(work_set));
 
 	return unit_test_summary();
 }
@@ -776,7 +776,7 @@ workfile_create_and_individual_cleanup(void)
 	unit_test_result(success);
 
 	/* the workfile_set should be freed since all it's files are closed */
-	unit_test_result(!work_set->active);
+	unit_test_result(!workfile_is_active(work_set));
 
 	return unit_test_summary();
 }
@@ -834,12 +834,12 @@ workfile_create_and_individual_cleanup_with_pinned_workfile_set(void)
 	unit_test_result(success);
 
 	/* the workfile_set should not be freed since it gets pinned */
-	unit_test_result(work_set->active);
+	unit_test_result(workfile_is_active(work_set));
 
 	/* free the workfile_set */
 	workfile_mgr_close_set(work_set);
 
-	unit_test_result(!work_set->active);
+	unit_test_result(!workfile_is_active(work_set));
 
 	return unit_test_summary();
 }


### PR DESCRIPTION
The struct workfile_set has a field named `operator`, which conflicts with C++ key words when its header workfile_mgr.h is included in C++ code.
Luckily, it has no need to expose in the header file. We just keep the type declaration in the header file, but define the structure in the C source code.


Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
