### PR TITLE
Add namespace pg_ext_aux for extension

### DIFF
--- a/src/backend/access/heap/heapam_visibility.c
+++ b/src/backend/access/heap/heapam_visibility.c
@@ -112,6 +112,7 @@ markDirty(Buffer buffer, Relation relation, HeapTupleHeader tuple, bool isXmin)
 	 */
 	if (relation == NULL ||
 		RelationGetRelid(relation) < FirstNormalObjectId ||
+		RelationGetNamespace(relation) == PG_EXTAUX_NAMESPACE ||
 		RelationGetNamespace(relation) == PG_AOSEGMENT_NAMESPACE)
 	{
 		MarkBufferDirtyHint(buffer, true);

--- a/src/backend/catalog/catalog.c
+++ b/src/backend/catalog/catalog.c
@@ -82,6 +82,7 @@
 #endif
 
 static bool IsAoSegmentClass(Form_pg_class reltuple);
+static bool IsExtAuxClass(Form_pg_class reltuple);
 
 /*
  * Like relpath(), but gets the directory containing the data file
@@ -179,6 +180,7 @@ IsSystemClass(Oid relid, Form_pg_class reltuple)
 {
 	/* IsCatalogRelationOid is a bit faster, so test that first */
 	return (IsCatalogRelationOid(relid) || IsToastClass(reltuple) ||
+			IsExtAuxClass(reltuple) ||
 			IsAoSegmentClass(reltuple));
 }
 
@@ -285,6 +287,14 @@ IsAoSegmentClass(Form_pg_class reltuple)
 	return IsAoSegmentNamespace(relnamespace);
 }
 
+static bool
+IsExtAuxClass(Form_pg_class reltuple)
+{
+	Oid			relnamespace = reltuple->relnamespace;
+
+	return IsExtAuxNamespace(relnamespace);
+}
+
 /*
  * IsCatalogNamespace
  *		True iff namespace is pg_catalog.
@@ -330,6 +340,12 @@ bool
 IsAoSegmentNamespace(Oid namespaceId)
 {
 	return namespaceId == PG_AOSEGMENT_NAMESPACE;
+}
+
+bool
+IsExtAuxNamespace(Oid namespaceId)
+{
+	return namespaceId == PG_EXTAUX_NAMESPACE;
 }
 
 /*

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1663,8 +1663,9 @@ heap_create_with_catalog(const char *relname,
 		  relkind == RELKIND_PARTITIONED_INDEX ||
 		  relkind == RELKIND_AOSEGMENTS ||
 		  relkind == RELKIND_AOBLOCKDIR ||
-		  relkind == RELKIND_AOVISIMAP) &&
-		relnamespace != PG_BITMAPINDEX_NAMESPACE)
+		  relkind == RELKIND_AOVISIMAP ||
+		  relnamespace == PG_BITMAPINDEX_NAMESPACE ||
+		  relnamespace == PG_EXTAUX_NAMESPACE))
 	{
 		/* OK, so pre-assign a type OID for the array type */
 		Oid			new_array_oid;
@@ -1934,6 +1935,7 @@ heap_create_with_catalog(const char *relname,
 			case PG_TOAST_NAMESPACE:
 			case PG_BITMAPINDEX_NAMESPACE:
 			case PG_AOSEGMENT_NAMESPACE:
+			case PG_EXTAUX_NAMESPACE:
 				doIt = false;
 				break;
 			default:

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -1104,6 +1104,7 @@ index_create_internal(Relation heapRelation,
 			case PG_TOAST_NAMESPACE:
 			case PG_BITMAPINDEX_NAMESPACE:
 			case PG_AOSEGMENT_NAMESPACE:
+			case PG_EXTAUX_NAMESPACE:
 				doIt = false;
 				break;
 			default:
@@ -4011,6 +4012,7 @@ reindex_index(Oid indexId, bool skip_constraint_checks, char persistence,
 			case PG_TOAST_NAMESPACE:
 			case PG_BITMAPINDEX_NAMESPACE:
 			case PG_AOSEGMENT_NAMESPACE:
+			case PG_EXTAUX_NAMESPACE:
 				doIt = false;
 				break;
 			default:

--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -3060,6 +3060,12 @@ CheckSetNamespace(Oid oldNspOid, Oid nspOid)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("cannot move objects into or out of AO SEGMENT schema")));
+
+	/* same for EXT AUX schema */
+	if (nspOid == PG_EXTAUX_NAMESPACE || oldNspOid == PG_EXTAUX_NAMESPACE)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("cannot move objects into or out of namespace pg_ext_aux")));
 }
 
 /*

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1519,6 +1519,7 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 #define METATRACK_VALIDNAMESPACE(namespaceId) \
 	(namespaceId != PG_TOAST_NAMESPACE &&	\
 	 namespaceId != PG_BITMAPINDEX_NAMESPACE && \
+	 namespaceId != PG_EXTAUX_NAMESPACE && \
 	 namespaceId != PG_AOSEGMENT_NAMESPACE )
 
 /* check for valid namespace and valid relkind */
@@ -15263,6 +15264,7 @@ ATExecChangeOwner(Oid relationOid, Oid newOwnerId, bool recursing, LOCKMODE lock
 			tuple_class->relkind == RELKIND_PARTITIONED_TABLE ||
 			tuple_class->relkind == RELKIND_MATVIEW ||
 			tuple_class->relkind == RELKIND_TOASTVALUE ||
+			tuple_class->relnamespace == PG_EXTAUX_NAMESPACE ||
 			IsAppendonlyMetadataRelkind(tuple_class->relkind))
 		{
 			List	   *index_oid_list;

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -3324,6 +3324,7 @@ vacuumStatement_IsTemporary(Relation onerel)
 		case PG_TOAST_NAMESPACE:
 		case PG_BITMAPINDEX_NAMESPACE:
 		case PG_AOSEGMENT_NAMESPACE:
+		case PG_EXTAUX_NAMESPACE:
 			bTemp = true;
 			break;
 		default:

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -40,6 +40,7 @@ extern bool IsCatalogRelationOid(Oid relid);
 extern bool IsCatalogNamespace(Oid namespaceId);
 extern bool IsToastNamespace(Oid namespaceId);
 extern bool IsAoSegmentNamespace(Oid namespaceId);
+extern bool IsExtAuxNamespace(Oid namespaceId);
 
 extern bool IsReservedName(const char *name);
 extern char* GetReservedPrefix(const char *name);

--- a/src/include/catalog/pg_namespace.dat
+++ b/src/include/catalog/pg_namespace.dat
@@ -37,6 +37,9 @@
 { oid => '7012', oid_symbol => 'PG_BITMAPINDEX_NAMESPACE',
   descr => 'Reserved schema for internal relations of bitmap indexes',
   nspname => 'pg_bitmapindex', nspacl => '_null_' },
+{ oid => '7094', oid_symbol => 'PG_EXTAUX_NAMESPACE',
+  descr => 'Reserved schema for internal relations for extensions',
+  nspname => 'pg_ext_aux', nspacl => '_null_' },
 
 # prototypes for functions in pg_namespace.c
 

--- a/src/include/catalog/pg_namespace.h
+++ b/src/include/catalog/pg_namespace.h
@@ -57,8 +57,9 @@ typedef FormData_pg_namespace *Form_pg_namespace;
 #define IsBuiltInNameSpace(namespaceId) \
 	(namespaceId == PG_CATALOG_NAMESPACE || \
 	 namespaceId == PG_TOAST_NAMESPACE || \
-	 namespaceId == PG_BITMAPINDEX_NAMESPACE || \
 	 namespaceId == PG_PUBLIC_NAMESPACE || \
+	 namespaceId == PG_EXTAUX_NAMESPACE || \
+	 namespaceId == PG_BITMAPINDEX_NAMESPACE || \
 	 namespaceId == PG_AOSEGMENT_NAMESPACE)
 
 DECLARE_TOAST(pg_namespace, 4163, 4164);


### PR DESCRIPTION
New table access method(TAM) may have their own internal auxiliary tables, like AO tables have the visimap table, aoseg files, block directory tables. The auxiliary tale is not real user data. It's used to maintain the data structure of the new TAM. The auxiliary table should be protected by the system, or modifying the auxiliary table, by the user, will corrupt the user table.

This namespace mainly allows the extensions to have their internal auxiliary tables and protects them. The namespace of the auxiliary tables is not allowed to change, at least it's not necessary at the moment.

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
