### PR TITLE
Add callback in TableAmRoutine to handle swapping relation files

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -2181,6 +2181,14 @@ aoco_scan_sample_next_tuple(TableScanDesc scan, SampleScanState *scanstate,
 	return ret;
 }
 
+static void
+aoco_swap_relation_files(Oid relid1, Oid relid2,
+						 TransactionId  frozenXid pg_attribute_unused(),
+						 MultiXactId cutoffMulti pg_attribute_unused())
+{
+	SwapAppendonlyEntries(relid1, relid2);
+}
+
 /* ------------------------------------------------------------------------
  * Definition of the AO_COLUMN table access method.
  *
@@ -2258,6 +2266,7 @@ static TableAmRoutine ao_column_methods = {
 	.scan_sample_next_tuple = aoco_scan_sample_next_tuple,
 
 	.amoptions = ao_amoptions,
+	.swap_relation_files = aoco_swap_relation_files,
 };
 
 Datum

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -2314,6 +2314,14 @@ appendonly_scan_sample_next_tuple(TableScanDesc scan, SampleScanState *scanstate
 	return ret;
 }
 
+static void
+appendonly_swap_relation_files(Oid relid1, Oid relid2,
+								TransactionId  frozenXid pg_attribute_unused(),
+								MultiXactId cutoffMulti pg_attribute_unused())
+{
+	SwapAppendonlyEntries(relid1, relid2);
+}
+
 /* ------------------------------------------------------------------------
  * Definition of the appendonly table access method.
  *
@@ -2385,6 +2393,7 @@ static const TableAmRoutine ao_row_methods = {
 	.scan_sample_next_tuple = appendonly_scan_sample_next_tuple,
 
 	.amoptions = ao_amoptions,
+	.swap_relation_files = appendonly_swap_relation_files,
 };
 
 Datum

--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -892,6 +892,17 @@ typedef struct TableAmRoutine
 	 */
 	bytea       *(*amoptions)(Datum reloptions, char relkind, bool validate);
 
+	/*
+	 * This callback is used to swap internal auxiliary relation if
+	 * the table AM use different layout structure to organize tuples.
+	 *
+	 * Standard heap relation will swap the heap relation itself and optional
+	 * toast relation. Custom table AM could have different data structure,
+	 * like AO-row/AO-col tables have several auxiliary relations.
+	 * This behavior is table AM-specific.
+	 */
+	void		(*swap_relation_files) (Oid relid1, Oid relid2, TransactionId frozenXid, MultiXactId cutoffMulti);
+
 } TableAmRoutine;
 
 


### PR DESCRIPTION
Custom table access method may have internal auxiliary relatioins on how to access tuples, like segfile/visimap/block directory in AO/CO tables. The kernel only handles swapping objects for standard heap table:
1. swap entries in pg_class
2. swap optional toast tables

The internal auxiliary relations keep the old structure for the new table, which is definitely wrong.
This commit adds a new callback to swap the internal auxiliary relations for AO/CO and custom table AM.


Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
