### PR TITLE
Dispatch by shared memory

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -82,6 +82,7 @@
 #include "utils/snapmgr.h"
 #include "utils/timeout.h"
 #include "utils/timestamp.h"
+#include "utils/sharedqueryplan.h"
 #include "pg_trace.h"
 
 #include "access/distributedlog.h"
@@ -3557,6 +3558,7 @@ AbortTransaction(void)
 	AtAbort_Portals();
 	AtAbort_DispatcherState();
 	AtEOXact_SharedSnapshot();
+	AtAbort_SharedQueryPlan();
 
 	/* Perform any Resource Scheduler abort procesing. */
 	if ((Gp_role == GP_ROLE_DISPATCH || IS_SINGLENODE()) && IsResQueueEnabled())

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -354,6 +354,13 @@ cdbdisp_makeDispatchParams(CdbDispatcherState *ds,
 	MemoryContextSwitchTo(oldContext);
 }
 
+void
+cdbdisp_setDispatchParamsQueryText(CdbDispatcherState *ds, char *queryText, int queryTextLen)
+{
+	(pDispatchFuncs->setDispatchParamsQueryText)(ds, queryText, queryTextLen);
+}
+
+
 /*
  * Free memory in CdbDispatcherState
  *

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -95,6 +95,8 @@ typedef struct CdbDispatchCmdAsync
 
 static void *cdbdisp_makeDispatchParams_async(int maxSlices, int largestGangSize, char *queryText, int len);
 
+static void cdbdisp_setDispatchParamsQueryText_async(struct CdbDispatcherState *ds, char *queryText, int queryTextLen);
+
 static bool cdbdisp_checkAckMessage_async(struct CdbDispatcherState *ds, const char *message,
 									int timeout_sec);
 
@@ -114,6 +116,7 @@ DispatcherInternalFuncs DispatcherAsyncFuncs =
 	cdbdisp_checkForCancel_async,
 	cdbdisp_getWaitSocketFds_async,
 	cdbdisp_makeDispatchParams_async,
+	cdbdisp_setDispatchParamsQueryText_async,
 	cdbdisp_checkAckMessage_async,
 	cdbdisp_checkDispatchResult_async,
 	cdbdisp_dispatchToGang_async,
@@ -437,6 +440,19 @@ cdbdisp_makeDispatchParams_async(int maxSlices, int largestGangSize, char *query
 	pParms->query_text_len = len;
 
 	return (void *) pParms;
+}
+
+/*
+ * Set queryText in an already allocated CdbDispatchCmdAsync structure.
+ *
+ * Need to call cdbdisp_makeDispatchParams_async first.
+ */
+static void
+cdbdisp_setDispatchParamsQueryText_async(struct CdbDispatcherState *ds, char *queryText, int queryTextLen)
+{
+	CdbDispatchCmdAsync *pParms = (CdbDispatchCmdAsync *) ds->dispatchParams;
+	pParms->query_text = queryText;
+	pParms->query_text_len = queryTextLen;
 }
 
 /*

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -62,6 +62,7 @@
 #include "utils/resource_manager.h"
 #include "utils/faultinjector.h"
 #include "utils/sharedsnapshot.h"
+#include "utils/sharedqueryplan.h"
 #include "utils/gpexpand.h"
 #include "utils/snapmgr.h"
 
@@ -155,6 +156,7 @@ CreateSharedMemoryAndSemaphores(void)
 		size = add_size(size, dsm_estimate_size());
 		size = add_size(size, BufferShmemSize());
 		size = add_size(size, GpParallelDSMHashSize());
+		size = add_size(size, SharedQueryPlanHashSize());
 		size = add_size(size, LockShmemSize());
 		size = add_size(size, PredicateLockShmemSize());
 
@@ -315,6 +317,7 @@ CreateSharedMemoryAndSemaphores(void)
 	InitBufferPool();
 
 	InitGpParallelDSMHash();
+	InitSharedQueryPlanHash();
 
 	/*
 	 * Set up lock manager

--- a/src/backend/storage/lmgr/lwlocknames.txt
+++ b/src/backend/storage/lmgr/lwlocknames.txt
@@ -74,3 +74,4 @@ GpParallelDSMHashLock               64
 LoginFailedControlLock				65
 LoginFailedSharedMemoryLock			66
 GPIVMResLock						67
+SharedQueryPlanLock                 68

--- a/src/backend/utils/time/Makefile
+++ b/src/backend/utils/time/Makefile
@@ -14,7 +14,8 @@ include $(top_builddir)/src/Makefile.global
 
 OBJS = \
 	combocid.o \
-	snapmgr.o
+	snapmgr.o \
+	sharedqueryplan.o
 
 OBJS += sharedsnapshot.o
 

--- a/src/backend/utils/time/sharedqueryplan.c
+++ b/src/backend/utils/time/sharedqueryplan.c
@@ -1,0 +1,203 @@
+#include "utils/sharedqueryplan.h"
+
+static ResourceOwner SharedQueryPlanResOwner = NULL;
+static HTAB *SharedQueryPlanHash;
+
+#define SHARED_QUERY_PLAN_TABLE_SIZE MaxConnections
+
+static void
+destroy_entry(SharedQueryPlanEntry *entry, bool isCommit);
+
+Size
+SharedQueryPlanHashSize(void)
+{
+	return hash_estimate_size(SHARED_QUERY_PLAN_TABLE_SIZE, sizeof(SharedQueryPlanEntry));
+}
+
+void
+InitSharedQueryPlanHash(void)
+{
+	HASHCTL ctl;
+	ctl.keysize = sizeof(gp_session_id);
+	ctl.entrysize = sizeof(SharedQueryPlanEntry);
+	SharedQueryPlanHash = ShmemInitHash("Shared Query Plans Hash",
+	                                    SHARED_QUERY_PLAN_TABLE_SIZE,
+	                                    SHARED_QUERY_PLAN_TABLE_SIZE,
+	                                    &ctl,
+	                                    HASH_ELEM | HASH_BLOBS);
+}
+
+void
+ReadSharedQueryPlan(char *serializedPlantree, int serializedPlantreelen, char *serializedQueryDispatchDesc, int serializedQueryDispatchDesclen)
+{
+	SharedQueryPlanEntry *entry;
+	dsm_segment *seg;
+	char *addr;
+	long sleep_per_check_us = 1 * 1000;
+	long timeout_us = 5 * 1000 * 1000;
+	long total_sleep_time_us = 0;
+	long warning_sleep_time_us = 0;
+	for (;;)
+	{
+		LWLockAcquire(SharedQueryPlanLock, LW_EXCLUSIVE);
+		entry = (SharedQueryPlanEntry *) hash_search(SharedQueryPlanHash,
+		                                             &gp_session_id,
+		                                             HASH_FIND,
+		                                             NULL);
+		if (entry && entry->commandCount == gp_command_count)
+		{
+			seg = dsm_attach(entry->handle);
+			if (seg == NULL)
+				ereport(ERROR, errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
+				        errmsg("Dispatch by shmem commandCount matched but dsm_attach returns NULL"),
+				        errdetail("May due to out of memory. Please retry. "
+				                  "commandCount = %d (local %d), handle = %u",
+				                  entry->commandCount, gp_command_count, entry->handle));
+
+			addr = dsm_segment_address(seg);
+			memcpy(serializedPlantree, addr, serializedPlantreelen);
+			memcpy(serializedQueryDispatchDesc, addr + serializedPlantreelen, serializedQueryDispatchDesclen);
+			dsm_detach(seg);
+
+			entry->reference--;
+			Assert(entry->reference >= 0);
+			if (entry->reference == 0)
+				destroy_entry(entry, true);
+			LWLockRelease(SharedQueryPlanLock);
+			return;
+		}
+		if (warning_sleep_time_us > 1000 * 1000)
+		{
+			/* log a warning every second */
+			ereport(LOG, errmsg("ReadSharedQueryPlan did not find shared plan. "
+			                    "We are waiting for writer QE of session %d to set shared "
+			                    "serializedPlantree and serializedQueryDispatchDesc for commandCount %d "
+			                    "but it is currently %d. Already waited for %ldus and will time out at %ldus.",
+			                    gp_session_id,
+			                    gp_command_count,
+			                    entry ? entry->commandCount : -1,
+			                    total_sleep_time_us,
+			                    timeout_us));
+			warning_sleep_time_us = 0;
+		}
+		LWLockRelease(SharedQueryPlanLock);
+
+		if (total_sleep_time_us >= timeout_us)
+			ereport(ERROR, errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
+			        errmsg("ReadSharedQueryPlan timed out after %ldus waiting for writer QE to set shared plan.", total_sleep_time_us),
+			        errdetail("We are waiting for writer QE of session %d to set shared "
+			                  "serializedPlantree and serializedQueryDispatchDesc for commandCount %d "
+			                  "but it is currently %d. This may due to network congestion, please retry.",
+			                  gp_session_id,
+			                  gp_command_count,
+			                  entry ? entry->commandCount : -1));
+
+		pg_usleep(sleep_per_check_us);
+
+		CHECK_FOR_INTERRUPTS();
+
+		total_sleep_time_us += sleep_per_check_us;
+		warning_sleep_time_us += sleep_per_check_us;
+	}
+}
+
+void
+WriteSharedQueryPlan(const char *serializedPlantree, int serializedPlantreelen, const char *serializedQueryDispatchDesc, int serializedQueryDispatchDesclen, const SliceTable *sliceTable)
+{
+	int i;
+	ExecSlice *slice = NULL;
+	ExecSlice *local = NULL;
+
+	LWLockAcquire(SharedQueryPlanLock, LW_EXCLUSIVE);
+	local = &sliceTable->slices[sliceTable->localSlice];
+	int referenced = local->parallel_workers - 1; // referenced counts how many *other* QE need to read from this SharedQueryPlan
+	for (i = 0; i < sliceTable->numSlices; i++)
+	{
+		slice = &sliceTable->slices[i];
+		if (slice->sliceIndex == sliceTable->localSlice)
+			continue;
+		// there can be multiple roots when plan contains InitPlan, only consider those who're in the same root
+		if (slice->rootIndex != local->rootIndex)
+			continue;
+		if (slice->gangType == GANGTYPE_PRIMARY_WRITER || slice->gangType == GANGTYPE_PRIMARY_READER || slice->gangType == GANGTYPE_SINGLETON_READER)
+		{
+			ListCell *segment_cell;
+			foreach(segment_cell, slice->segments)
+			{
+				referenced += lfirst_int(segment_cell) == GpIdentity.segindex;
+			}
+		}
+	}
+	Assert(referenced >= 0);
+
+	if (referenced > 0)
+	{
+		bool found;
+		SharedQueryPlanEntry *entry;
+		ResourceOwner oldowner;
+		Size size = serializedPlantreelen + serializedQueryDispatchDesclen;
+
+		entry = (SharedQueryPlanEntry *) hash_search(SharedQueryPlanHash,
+		                                             &gp_session_id,
+		                                             HASH_ENTER,
+		                                             &found);
+		Assert(!found);
+		if (!SharedQueryPlanResOwner)
+			SharedQueryPlanResOwner = ResourceOwnerCreate(NULL, "SharedQueryPlanResOwner");
+
+		oldowner = CurrentResourceOwner;
+		CurrentResourceOwner = SharedQueryPlanResOwner;
+		dsm_segment *seg = dsm_create(size, 0);
+		dsm_handle handle = dsm_segment_handle(seg);
+		char *addr = dsm_segment_address(seg);
+		memcpy(addr, serializedPlantree, serializedPlantreelen);
+		memcpy(addr + serializedPlantreelen, serializedQueryDispatchDesc, serializedQueryDispatchDesclen);
+		entry->session_id = gp_session_id;
+		entry->reference = referenced;
+		entry->commandCount = gp_command_count;
+		entry->handle = handle;
+
+		/* pin seg to avoid being reclaimed, do that later in ReadSharedQueryPlan */
+		dsm_pin_segment(seg);
+		dsm_detach(seg);
+		CurrentResourceOwner = oldowner;
+	}
+	LWLockRelease(SharedQueryPlanLock);
+}
+
+/* this routine must be called with SharedQueryPlanLock held in exclusive mode */
+static void
+destroy_entry(SharedQueryPlanEntry *entry, bool isCommit)
+{
+	bool found;
+	dsm_unpin_segment(entry->handle);
+	ResourceOwnerRelease(SharedQueryPlanResOwner, RESOURCE_RELEASE_BEFORE_LOCKS, isCommit, true);
+	entry->handle = DSM_HANDLE_INVALID;
+	hash_search(SharedQueryPlanHash,
+	            &gp_session_id,
+	            HASH_REMOVE,
+	            &found);
+	Assert(found);
+}
+
+static void
+at_abort_discard_entry(void)
+{
+	SharedQueryPlanEntry *entry;
+	LWLockAcquire(SharedQueryPlanLock, LW_EXCLUSIVE);
+	entry = (SharedQueryPlanEntry *) hash_search(SharedQueryPlanHash,
+	                                             &gp_session_id,
+	                                             HASH_FIND,
+	                                             NULL);
+	if (entry)
+	{
+		destroy_entry(entry, false);
+	}
+	LWLockRelease(SharedQueryPlanLock);
+}
+
+void
+AtAbort_SharedQueryPlan(void)
+{
+	at_abort_discard_entry();
+}

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -58,6 +58,7 @@ typedef struct DispatcherInternalFuncs
 	bool (*checkForCancel)(struct CdbDispatcherState *ds);
 	int* (*getWaitSocketFds)(struct CdbDispatcherState *ds, int *nsocks);
 	void* (*makeDispatchParams)(int maxSlices, int largestGangSize, char *queryText, int queryTextLen);
+	void (*setDispatchParamsQueryText)(struct CdbDispatcherState *ds, char *queryText, int queryTextLen);
 	bool (*checkAckMessage)(struct CdbDispatcherState *ds, const char* message, int timeout_sec);
 	void (*checkResults)(struct CdbDispatcherState *ds, DispatchWaitMode waitMode);
 	void (*dispatchToGang)(struct CdbDispatcherState *ds, struct Gang *gp, int sliceIndex);
@@ -208,6 +209,7 @@ cdbdisp_makeDispatchParams(CdbDispatcherState *ds,
 						   int maxSlices,
 						   char *queryText,
 						   int queryTextLen);
+void cdbdisp_setDispatchParamsQueryText(CdbDispatcherState *ds, char *queryText, int queryTextLen);
 
 bool cdbdisp_checkForCancel(CdbDispatcherState * ds);
 int *cdbdisp_getWaitSocketFds(CdbDispatcherState *ds, int *nsocks);

--- a/src/include/utils/sharedqueryplan.h
+++ b/src/include/utils/sharedqueryplan.h
@@ -1,0 +1,30 @@
+#include "c.h"
+#include "miscadmin.h"
+#include "postgres.h"
+#include "resowner.h"
+#include "cdb/cdbdtxcontextinfo.h"
+#include "cdb/cdbvars.h"
+#include "executor/execdesc.h"
+#include "storage/dsm.h"
+#include "storage/lwlock.h"
+#include "storage/shmem.h"
+#include "storage/barrier.h"
+
+#define UseSharedQueryPlan() (!QEDtxContextInfo.cursorContext && GpIdentity.segindex >= 0)
+
+typedef struct SharedQueryPlanData
+{
+	int        session_id;
+	dsm_handle handle;
+	int        reference;
+	int        commandCount;
+} SharedQueryPlanEntry;
+
+extern void InitSharedQueryPlanHash(void);
+extern Size SharedQueryPlanHashSize(void);
+
+void ReadSharedQueryPlan(char *serializedPlantree, int serializedPlantreelen, char *serializedQueryDispatchDesc, int serializedQueryDispatchDesclen);
+
+void WriteSharedQueryPlan(const char *serializedPlantree, int serializedPlantreelen, const char *serializedQueryDispatchDesc, int serializedQueryDispatchDesclen, const SliceTable *sliceTable);
+
+extern void AtAbort_SharedQueryPlan(void);


### PR DESCRIPTION
This PR makes `serializedPlantree` and `serializedQueryDispatchDesc` dispatched by shared memory instead of interconnect, so that they can be sent only once to writer QE, and synced inbetween reader QEs and writer QE on a segment through DSM. It has been discussed in https://github.com/orgs/cloudberrydb/discussions/243.

## Implementation Outline

- this PR mainly use **polling** on reader QE to wait shared plan get's dispatched from writer QE. this is the same mechanism as shared snapshot synchronization. to circumvent this we may need something special (e.g., signal) because seems current synchronization mechanisms (`barrier`, SharedLatch) cannot satisfy our requirement.
- to properly reclaim DSM segments for a query, a `reference` count is calculated on writer QE. and **the last** reader QE who reads it will reclaim the DSM. this is the same as parallel (`GpInsertParallelDSMHash`).
- to isolate states in each user connections, a shmem HTAB is used. also same as parallel.

## Prerequisites

This feature is only enabled when: **1)** current query is _not_ an extended query (cursor, or `Bind` messages, etc.), and **2)** there exists a gang in which **all** QEs are writer QE (notably, writer QE and writer gang are two different concepts).

#### Prerequisite 1
prerequisite 1 is a hard limit due to the way extended query (equery for short) works. during equery, there's always a live writer gang in which everyone's a writer QE (gang W). first a command `set gp_write_shared_snapshot=true` will be dispatched to gang W to force a shared snapshot sync, then the actual gang will be created in which everyone's reader (gang R) and the actual query gets dispatched to it. Immediately you can find out that when the actual query get's dispatched, no writer QE receives the plan (because all writer QEs are in gang W), so there's no one be responsible for shared query plan synchronization.

#### Prerequisite 2

prerequisite 2 is a tradeoff. Consider the following query plan:

![image](https://github.com/cloudberrydb/cloudberrydb/assets/7938763/15e0610f-54ee-4c02-ae7e-6eaba4e20763)

In this plan, seg0 in slice1 is a writer that should receives full query text. but in slice2, seg0 is a reader that should receive `slimQueryText` (a `slimQueryText` is a query text w/o query plan and ddesc), and seg1 and seg2 are writer QEs. this means when dispatching to gang2, seg0 should receives slim query text (because the full plan can be synced to it from seg0 in slice1 which is a writer), but seg1 and seg2 should receives full query text. this poses challenges because on QD side, the current interface of cdb dispatcher limits **all dispatches happens on a per-gang basis** (`cdbdisp_dispatchToGang`) and plan cannot be changed from seg to seg in a gang. for the same reason, the reference count of a DSM segment cannot be dispatched from QD directly because it may be different from QE to QE, even they're in the same gang (consider a plan that have singleton reader).

We can surely workaround this by bringing more thorough refactor to cdb/dispatcher interfaces. but I don't think that's worth it though surely this's debatable.

## Other Caveats

#### Updatable Views

It may seem that the following invariant holds for any given query:

> For any segment that a plan touches, there's always a writer QE exists on that segment.

This is indeed true for many common queries, but unfortunately not all of them. Below is a counterexample:

![image](https://github.com/cloudberrydb/cloudberrydb/assets/7938763/e9bf599c-5dcd-4641-8c88-379450849912)

#### `InitPlan`

If there's a`InitPlan` _at the root_ of a plan, there could be **two set of writer gang** created and **two rounds of dispatching happens** for the same query:

![image](https://github.com/cloudberrydb/cloudberrydb/assets/7938763/7bfd5ebf-d5e0-4955-a1d1-b01dc9425b8e)

this is why we limit "same root" during `reference` calculation (https://github.com/Ray-Eldath/cloudberrydb/blob/dispatch-by-shmem/organized-and-unlogged/src/backend/utils/time/sharedqueryplan.c#L119-L121). Note that a `InitPlan` doesn't necessarily have to be at the root. It could be deep down the plan tree as well:

<img width="838" alt="image" src="https://github.com/cloudberrydb/cloudberrydb/assets/7938763/27018cca-0c3d-4fd9-83a3-10f557ef9526">

## Possible Outcome

All in all, though many requirements need to be meet for this feature to take effects, it is still very much **turned on** in most common queries (see tests for example). This is good news. On the bad side, I doubt whether this PR can make any noticeable performance improvements at all. On qd, we cannot completely get rid of libpq connections for now, and query dispatch is already **pipelined** to hide interconnect cost anyway. In the long run, if we are to "decentralize" QE by reassigning tasks (such as creating reader QEs, keepalive, etc.) to writer QE, this feature is a very good pathfinder and also a mandatory requisite. But if that's not the case, I doubt whether this feature alone worths the risk.