### PR TITLE
Fix issues about namespace pg_ext_aux

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -368,6 +368,7 @@ heap_create(const char *relname,
 	if (!allow_system_table_mods &&
 		((IsCatalogNamespace(relnamespace) && relkind != RELKIND_INDEX) ||
 		 IsToastNamespace(relnamespace) ||
+		 IsExtAuxNamespace(relnamespace) ||
 		 IsAoSegmentNamespace(relnamespace)) &&
 		IsNormalProcessingMode())
 		ereport(ERROR,

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -3695,7 +3695,7 @@ RelationBuildLocalRelation(const char *relname,
 			rel->rd_islocaltemp = false;
 			break;
 		case RELPERSISTENCE_TEMP:
-			Assert(isTempOrTempToastNamespace(relnamespace));
+			Assert(relnamespace == PG_EXTAUX_NAMESPACE || isTempOrTempToastNamespace(relnamespace));
 			rel->rd_backend = BackendIdForTempRelations();
 			rel->rd_islocaltemp = true;
 			break;

--- a/src/include/catalog/dependency.h
+++ b/src/include/catalog/dependency.h
@@ -142,9 +142,9 @@ typedef enum ObjectClass
 
 	/* GPDB additions */
 	OCLASS_PROFILE,                         /* pg_profile */
-        OCLASS_PASSWORDHISTORY,                 /* pg_password_history */
+	OCLASS_PASSWORDHISTORY,                 /* pg_password_history */
 	OCLASS_EXTPROTOCOL,			/* pg_extprotocol */
-	OCLASS_TASK					/* pg_task */
+	OCLASS_TASK,				/* pg_task */
 } ObjectClass;
 
 #define LAST_OCLASS		OCLASS_TASK


### PR DESCRIPTION
Namespace pg_ext_aux is different from the normal namespace created by the user. It's only used internally. The user isn't allowed to create table in pg_ext_aux explicitly.

For temp table, the namespace of the auxiliary table is also pg_ext_aux, not a temp namespace. It seems complicated to distinguish pg_ext_aux and pg_ext_aux_temp. The temp table will be automatically dropped when either the table is dropped or the session is closed. The internal auxiliary relation depends on the table will also automatically dropped if its table is dropped.

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
