### PR TITLE
Rename postgres.so to libpostgres.so

### DIFF
--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -47,7 +47,7 @@ LOCALOBJS += utils/probes.o
 endif
 endif
 
-# FIXME: The --enable-shared-postgres-backend parameter build the postgres.so shared between postmaster
+# FIXME: The --enable-shared-postgres-backend parameter build the libpostgres.so shared between postmaster
 # But we only test it locally without CI test. Please use it with caution.
 ifeq ($(enable_shared_postgres_backend),yes)
 OBJS = $(LOCALOBJS) $(SUBDIROBJS)
@@ -86,12 +86,12 @@ ifneq ($(PORTNAME), win32)
 ifneq ($(PORTNAME), aix)
 
 ifeq ($(enable_shared_postgres_backend),yes)
-postgres.so: $(OBJS)
+libpostgres.so: $(OBJS)
 	$(CXX) -shared $(CXXFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) $(filter-out main/main.o, $(call expand_subsys,$^)) -o $@
 
-postgres: main/main.o postgres.so $(top_builddir)/src/port/libpgport_srv.a $(top_builddir)/src/common/libpgcommon_srv.a
+postgres: main/main.o libpostgres.so $(top_builddir)/src/port/libpgport_srv.a $(top_builddir)/src/common/libpgcommon_srv.a
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) \
-	  main/main.o postgres.so $(top_builddir)/src/port/libpgport_srv.a \
+	  main/main.o -lpostgres $(top_builddir)/src/port/libpgport_srv.a \
 	  $(top_builddir)/src/common/libpgcommon_srv.a $(LIBS) -o $@
 else
 postgres: $(OBJS)
@@ -272,7 +272,7 @@ endif
 install-bin: postgres $(POSTGRES_IMP) installdirs
 	$(INSTALL_PROGRAM) postgres$(X) '$(DESTDIR)$(bindir)/postgres$(X)'
 ifeq ($(enable_shared_postgres_backend),yes)
-	$(INSTALL_PROGRAM) postgres.so '$(DESTDIR)$(libdir)/postgres.so'
+	$(INSTALL_PROGRAM) libpostgres.so '$(DESTDIR)$(libdir)/libpostgres.so'
 endif
 ifneq ($(PORTNAME), win32)
 	@rm -f $(DESTDIR)$(bindir)/postmaster$(X)
@@ -311,7 +311,7 @@ endif
 uninstall:
 	rm -f $(DESTDIR)$(bindir)/postgres$(X) $(DESTDIR)$(bindir)/postmaster $(DESTDIR)$(bindir)/cdbsyncmaster
 ifeq ($(enable_shared_postgres_backend),yes)
-	rm -f $(DESTDIR)$(bindir)/postgres$(X) $(DESTDIR)$(libdir)/postgres.so $(DESTDIR)$(bindir)/postmaster $(DESTDIR)$(bindir)/cdbsyncmaster
+	rm -f $(DESTDIR)$(bindir)/postgres$(X) $(DESTDIR)$(libdir)/libpostgres.so $(DESTDIR)$(bindir)/postmaster $(DESTDIR)$(bindir)/cdbsyncmaster
 endif
 ifeq ($(MAKE_EXPORTS), true)
 	rm -f '$(DESTDIR)$(pkglibdir)/$(POSTGRES_IMP)'
@@ -349,7 +349,7 @@ endif
 clean:
 	rm -f $(LOCALOBJS) postgres$(X) $(POSTGRES_IMP)
 ifeq ($(enable_shared_postgres_backend),yes)
-	rm -f $(LOCALOBJS) postgres.so $(POSTGRES_IMP)
+	rm -f $(LOCALOBJS) libpostgres.so $(POSTGRES_IMP)
 endif
 ifeq ($(PORTNAME), cygwin)
 	rm -f postgres.dll libpostgres.a

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -49,16 +49,12 @@ endif
 
 # FIXME: The --enable-shared-postgres-backend parameter build the libpostgres.so shared between postmaster
 # But we only test it locally without CI test. Please use it with caution.
-ifeq ($(enable_shared_postgres_backend),yes)
-OBJS = $(LOCALOBJS) $(SUBDIROBJS)
-else
 OBJS = \
 	$(LOCALOBJS) \
 	$(SUBDIROBJS) \
 	$(top_builddir)/src/common/libpgcommon_srv.a \
 	$(top_builddir)/src/port/libpgport_srv.a
 
-endif
 ifeq ($(PORTNAME), darwin)
 LDOPTS = -Z
 endif
@@ -87,12 +83,14 @@ ifneq ($(PORTNAME), aix)
 
 ifeq ($(enable_shared_postgres_backend),yes)
 libpostgres.so: $(OBJS)
-	$(CXX) -shared $(CXXFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) $(filter-out main/main.o, $(call expand_subsys,$^)) -o $@
+	$(CXX) -shared $(CXXFLAGS) $(LDFLAGS) $(LDFLAGS_SL) $(export_dynamic) \
+	  $(filter-out main/main.o, $(call expand_subsys,$^)) $(LIBS) -o $@
 
 postgres: main/main.o libpostgres.so $(top_builddir)/src/port/libpgport_srv.a $(top_builddir)/src/common/libpgcommon_srv.a
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) \
-	  main/main.o -lpostgres $(top_builddir)/src/port/libpgport_srv.a \
+	  main/main.o libpostgres.so $(top_builddir)/src/port/libpgport_srv.a \
 	  $(top_builddir)/src/common/libpgcommon_srv.a $(LIBS) -o $@
+
 else
 postgres: $(OBJS)
 	$(CXX) $(CXXFLAGS) $(call expand_subsys,$^) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) $(LIBS) -o $@
@@ -152,13 +150,8 @@ $(top_builddir)/src/port/libpgport_srv.a: | submake-libpgport
 
 # The postgres.o target is needed by the rule in Makefile.global that
 # creates the exports file when MAKE_EXPORTS = true.
-ifeq ($(enable_shared_postgres_backend),yes)
-postgres.o: $(OBJS)  $(top_builddir)/src/port/libpgport_srv.a $(top_builddir)/src/common/libpgcommon_srv.a
-	$(CXX) $(LDREL) $(call expand_subsys,$^) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@
-else
 postgres.o: $(OBJS)
 	$(CXX) $(LDREL) $(call expand_subsys,$^) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@
-endif
 
 # The following targets are specified in make commands that appear in
 # the make files in our subdirectories. Note that it's important we


### PR DESCRIPTION
The postgres library `postgres.so` could be linked by some extensions in their tests. It's unusual to use the name `postgres.so` when linking the library or program by `-lpostgres`.

To make the name standard and link the library by `-lpostgres`, the name of the postgres library is renamed to `libpostgres.so`.

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
