### PR TITLE
Feature: Orca optimizor support pax storage table

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -2433,6 +2433,19 @@ CTranslatorRelcacheToDXL::RetrieveRelStorageType(Relation rel)
 		case HEAP_TABLE_AM_OID:
 			rel_storage_type = IMDRelation::ErelstorageHeap;
 			break;
+		// FIXME: need to add support for custom table am!!!
+		//
+		// Why 7014 here?
+		// Because we defined a custom table am using columnar storage,
+		// the orca optimizer does not support am other than HEAP/AO/AOCS. At present,
+		// there is no way to extend orca to support custom table am. So here we use
+		// the am_id(7014) we assigned to the custom table am, and let the orca optimizer
+		// treat this columnar storage format as AOCS to generate an execution plan
+		//
+		// Why use the magic number 7014 instead of the macro definition?
+		// Just to make it look like it doesn't make sense,
+		// so others will notice that the logic needs to be refactored
+		case 7014:
 		case AO_COLUMN_TABLE_AM_OID:
 			rel_storage_type = IMDRelation::ErelstorageAppendOnlyCols;
 			break;


### PR DESCRIPTION
RetrieveRelStorageType add a magic number 7014. we use the am_id(7014) we assigned to the custom table am, and let the orca optimizer treat this columnar storage format as AOCS to generate an execution plan

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
