### PR TITLE
Fix compile error that pipe is redefined

### DIFF
--- a/gpcontrib/orafce/pipe.c
+++ b/gpcontrib/orafce/pipe.c
@@ -91,7 +91,7 @@ typedef struct {
 	int16 count;
 	int16 limit;
 	int size;
-} pipe;
+} pipe_desc;
 
 typedef struct {
 	int32 size;
@@ -130,7 +130,7 @@ typedef struct
 
 #endif
 
-	pipe *pipes;
+	pipe_desc *pipes;
 	alert_event *events;
 	alert_lock *locks;
 	size_t size;
@@ -143,7 +143,7 @@ typedef struct
 message_buffer *output_buffer = NULL;
 message_buffer *input_buffer = NULL;
 
-pipe* pipes = NULL;
+pipe_desc* pipes = NULL;
 
 #define NOT_INITIALIZED		NULL
 
@@ -274,7 +274,7 @@ ora_lock_shmem(size_t size, int max_pipes, int max_events, int max_locks, bool r
 
 			sh_mem->size = size - sh_memory_size;
 			ora_sinit(sh_mem->data, size, true);
-			pipes = sh_mem->pipes = ora_salloc(max_pipes*sizeof(pipe));
+			pipes = sh_mem->pipes = ora_salloc(max_pipes*sizeof(pipe_desc));
 			sid = sh_mem->sid = 1;
 			for (i = 0; i < max_pipes; i++)
 				pipes[i].is_valid = false;
@@ -347,11 +347,11 @@ ora_lock_shmem(size_t size, int max_pipes, int max_events, int max_locks, bool r
  * can be enhanced access/hash.h
  */
 
-static pipe*
+static pipe_desc*
 find_pipe(text* pipe_name, bool* created, bool only_check)
 {
 	int i;
-	pipe *result = NULL;
+	pipe_desc *result = NULL;
 
 	*created = false;
 	for (i = 0; i < MAX_PIPES; i++)
@@ -401,7 +401,7 @@ find_pipe(text* pipe_name, bool* created, bool only_check)
 
 
 static bool
-new_last(pipe *p, void *ptr)
+new_last(pipe_desc *p, void *ptr)
 {
 	queue_item *q, *aux_q;
 
@@ -436,7 +436,7 @@ new_last(pipe *p, void *ptr)
 
 
 static void*
-remove_first(pipe *p, bool *found)
+remove_first(pipe_desc *p, bool *found)
 {
 	struct _queue_item *q;
 	void *ptr = NULL;
@@ -468,7 +468,7 @@ remove_first(pipe *p, bool *found)
 static message_buffer*
 get_from_pipe(text *pipe_name, bool *found)
 {
-	pipe *p;
+	pipe_desc *p;
 	bool created;
 	message_buffer *shm_msg;
 	message_buffer *result = NULL;
@@ -504,7 +504,7 @@ get_from_pipe(text *pipe_name, bool *found)
 static bool
 add_to_pipe(text *pipe_name, message_buffer *ptr, int limit, bool limit_is_valid)
 {
-	pipe *p;
+	pipe_desc *p;
 	bool created;
 	bool result = false;
 	message_buffer *sh_ptr;
@@ -556,7 +556,7 @@ add_to_pipe(text *pipe_name, message_buffer *ptr, int limit, bool limit_is_valid
 static void
 remove_pipe(text *pipe_name, bool purge)
 {
-	pipe *p;
+	pipe_desc *p;
 	bool created;
 
 	if (NULL != (p = find_pipe(pipe_name, &created, true)))
@@ -1162,7 +1162,7 @@ dbms_pipe_create_pipe (PG_FUNCTION_ARGS)
 	WATCH_PRE(timeout, endtime, cycle);
 	if (ora_lock_shmem(SHMEMMSGSZ, MAX_PIPES,MAX_EVENTS,MAX_LOCKS,false))
 	{
-		pipe *p;
+		pipe_desc *p;
 		if (NULL != (p = find_pipe(pipe_name, &created, false)))
 		{
 			if (!created)


### PR DESCRIPTION
`pipe` is pre-declared as a function in system library. But, the source code in pipe.c re-define this symbol as a new type. It should be fine normally. But this behavior will cause an error in some environments, so rename this type name.

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
