### PR TITLE
[Answer Query Using Materialized Views] Support HAVING clause in origin query

### DIFF
--- a/src/test/regress/expected/aqumv.out
+++ b/src/test/regress/expected/aqumv.out
@@ -1434,6 +1434,151 @@ select c1, c3, count(c2) from aqumv_t3 where c1 > 90 group by cube(c1, c3);
 (32 rows)
 
 abort;
+--
+-- Test HAVING clause
+--
+begin;
+create table aqumv_t4(c1 int, c2 int, c3 int) distributed by (c1);
+insert into aqumv_t4 select i, i+1, i+2 from generate_series(1, 100) i;
+insert into aqumv_t4 values (91, NULL, 95);
+analyze aqumv_t4;
+create incremental materialized view aqumv_mvt4_0 as
+  select c1 as mc1, c2 as mc2, c3 as mc3
+  from aqumv_t4 where c1 > 90;
+analyze aqumv_mvt4_0;
+-- HAVING clause pushed down to where quals.
+set local enable_answer_query_using_materialized_views = off;
+explain(costs off, verbose)
+select c1, c3 from aqumv_t4 where c1 > 90 group by (c1, c3) having c3 > 97 ;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: c1, c3
+   ->  GroupAggregate
+         Output: c1, c3
+         Group Key: aqumv_t4.c1, aqumv_t4.c3
+         ->  Sort
+               Output: c1, c3
+               Sort Key: aqumv_t4.c1, aqumv_t4.c3
+               ->  Seq Scan on public.aqumv_t4
+                     Output: c1, c3
+                     Filter: ((aqumv_t4.c1 > 90) AND (aqumv_t4.c3 > 97))
+ Settings: enable_answer_query_using_materialized_views = 'off', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+select c1, c3 from aqumv_t4 where c1 > 90 group by (c1, c3) having c3 > 97 ;
+ c1  | c3  
+-----+-----
+  96 |  98
+ 100 | 102
+  97 |  99
+  99 | 101
+  98 | 100
+(5 rows)
+
+set local enable_answer_query_using_materialized_views = on;
+explain(costs off, verbose)
+select c1, c3 from aqumv_t4 where c1 > 90 group by (c1, c3) having c3 > 97 ;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: mc1, mc3
+   ->  HashAggregate
+         Output: mc1, mc3
+         Group Key: aqumv_mvt4_0.mc1, aqumv_mvt4_0.mc3
+         ->  Seq Scan on public.aqumv_mvt4_0
+               Output: mc1, mc2, mc3
+               Filter: (aqumv_mvt4_0.mc3 > 97)
+ Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select c1, c3 from aqumv_t4 where c1 > 90 group by (c1, c3) having c3 > 97 ;
+ c1  | c3  
+-----+-----
+ 100 | 102
+  96 |  98
+  98 | 100
+  99 | 101
+  97 |  99
+(5 rows)
+
+-- quals kept in HAVING clause.
+set local enable_answer_query_using_materialized_views = off;
+explain(costs off, verbose)
+select c1, c3, avg(c2) from aqumv_t4 where c1 > 90 group by (c1, c3) having avg(c2) > 95;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: c1, c3, (avg(c2))
+   ->  HashAggregate
+         Output: c1, c3, avg(c2)
+         Group Key: aqumv_t4.c1, aqumv_t4.c3
+         Filter: (avg(aqumv_t4.c2) > '95'::numeric)
+         ->  Seq Scan on public.aqumv_t4
+               Output: c1, c2, c3
+               Filter: (aqumv_t4.c1 > 90)
+ Settings: enable_answer_query_using_materialized_views = 'off', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select c1, c3, avg(c2) from aqumv_t4 where c1 > 90 group by (c1, c3) having avg(c2) > 95;
+ c1  | c3  |         avg          
+-----+-----+----------------------
+  99 | 101 | 100.0000000000000000
+  97 |  99 |  98.0000000000000000
+  98 | 100 |  99.0000000000000000
+  95 |  97 |  96.0000000000000000
+ 100 | 102 | 101.0000000000000000
+  96 |  98 |  97.0000000000000000
+(6 rows)
+
+set local enable_answer_query_using_materialized_views = on;
+explain(costs off, verbose)
+select c1, c3, avg(c2) from aqumv_t4 where c1 > 90 group by (c1, c3) having avg(c2) > 95;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: mc1, mc3, (avg(mc2))
+   ->  HashAggregate
+         Output: mc1, mc3, avg(mc2)
+         Group Key: aqumv_mvt4_0.mc1, aqumv_mvt4_0.mc3
+         Filter: (avg(aqumv_mvt4_0.mc2) > '95'::numeric)
+         ->  Seq Scan on public.aqumv_mvt4_0
+               Output: mc1, mc2, mc3
+ Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select c1, c3, avg(c2) from aqumv_t4 where c1 > 90 group by (c1, c3) having avg(c2) > 95;
+ c1  | c3  |         avg          
+-----+-----+----------------------
+  98 | 100 |  99.0000000000000000
+  95 |  97 |  96.0000000000000000
+  99 | 101 | 100.0000000000000000
+  97 |  99 |  98.0000000000000000
+ 100 | 102 | 101.0000000000000000
+  96 |  98 |  97.0000000000000000
+(6 rows)
+
+-- duplicated having quals with where quals.
+explain(costs off, verbose)
+select c1, c3, avg(c2) from aqumv_t4 where c1 > 90 group by (c1, c3) having c1 > 90;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: mc1, mc3, (avg(mc2))
+   ->  HashAggregate
+         Output: mc1, mc3, avg(mc2)
+         Group Key: aqumv_mvt4_0.mc1, aqumv_mvt4_0.mc3
+         ->  Seq Scan on public.aqumv_mvt4_0
+               Output: mc1, mc2, mc3
+ Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+abort;
 reset optimizer;
 reset enable_answer_query_using_materialized_views;
 drop table aqumv_t1 cascade;


### PR DESCRIPTION
Support HAVING clause of origin query if it could be computed from materialized views.

```sql
create incremental materialized view mv as
  select c1 as mc1, c2 as mc2, c3 as mc3
  from t1 where c1 > 90;
```
Origin query:
```sql
  select c1, c3, avg(c2) from t1 where c1 > 90
  group by (c1, c3) having avg(c2) > 95;
```
Could be rewritten to:
```sql
  select mc1, mc3, avg(mc2) from mv
  group by (mc1, mc3) having avg(mc2) > 95;
```

### For HAVING quals don't have aggregations, they may be pushed down to jointree's quals and would be processed in post_quals.

DDL:
```sql
create table aqumv_t4(c1 int, c2 int, c3 int) distributed by (c1);
insert into aqumv_t4 select i, i+1, i+2 from generate_series(1, 100) i;
insert into aqumv_t4 values (91, NULL, 95);
analyze aqumv_t4;
create incremental materialized view aqumv_mvt4_0 as
  select c1 as mc1, c2 as mc2, c3 as mc3
  from aqumv_t4 where c1 > 90;
analyze aqumv_mvt4_0;
```

```sql
begin;
-- HAVING clause pushed down to where quals.
set local enable_answer_query_using_materialized_views = off;
explain(costs off, verbose)
select c1, c3 from aqumv_t4 where c1 > 90 group by (c1, c3) having c3 > 97 ;
                                    QUERY PLAN                                     
-----------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   Output: c1, c3
   ->  GroupAggregate
         Output: c1, c3
         Group Key: aqumv_t4.c1, aqumv_t4.c3
         ->  Sort
               Output: c1, c3
               Sort Key: aqumv_t4.c1, aqumv_t4.c3
               ->  Seq Scan on public.aqumv_t4
                     Output: c1, c3
                     Filter: ((aqumv_t4.c1 > 90) AND (aqumv_t4.c3 > 97))
 Settings: enable_answer_query_using_materialized_views = 'off', optimizer = 'off'
 Optimizer: Postgres query optimizer
(13 rows)
set local enable_answer_query_using_materialized_views = on;
explain(costs off, verbose)
select c1, c3 from aqumv_t4 where c1 > 90 group by (c1, c3) having c3 > 97 ;
                                    QUERY PLAN                                    
----------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   Output: mc1, mc3
   ->  HashAggregate
         Output: mc1, mc3
         Group Key: aqumv_mvt4_0.mc1, aqumv_mvt4_0.mc3
         ->  Seq Scan on public.aqumv_mvt4_0
               Output: mc1, mc2, mc3
               Filter: (aqumv_mvt4_0.mc3 > 97)
 Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
 Optimizer: Postgres query optimizer
(10 rows)
end;
```
### For HAVING quals have aggregations, we process them in Aggrefs of target list.
```sql
explain(costs off, verbose)
select c1, c3, avg(c2) from aqumv_t4 where c1 > 90 group by (c1, c3) having avg(c2) > 95;
                                    QUERY PLAN                                    
----------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   Output: mc1, mc3, (avg(mc2))
   ->  HashAggregate
         Output: mc1, mc3, avg(mc2)
         Group Key: aqumv_mvt4_0.mc1, aqumv_mvt4_0.mc3
         Filter: (avg(aqumv_mvt4_0.mc2) > '95'::numeric)
         ->  Seq Scan on public.aqumv_mvt4_0
               Output: mc1, mc2, mc3
 Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
 Optimizer: Postgres query optimizer
(10 rows)
```

Authored-by: Zhang Mingli avamingli@gmail.com

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
