### PR TITLE
make `shareinput_Xslice_dsm_handle_ptr` and `shareinput_Xslice_hash` non-static

### DIFF
--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -118,7 +118,7 @@ typedef struct shareinput_Xslice_state
 } shareinput_Xslice_state;
 
 /* shared memory hash table holding 'shareinput_Xslice_state' entries */
-static HTAB *shareinput_Xslice_hash = NULL;
+HTAB *shareinput_Xslice_hash = NULL;
 
 /*
  * The tuplestore files for all share input scans are held in one SharedFileSet.
@@ -135,7 +135,7 @@ static HTAB *shareinput_Xslice_hash = NULL;
  * are reference counted separately, and we clean up the files backing each
  * individual ShareInputScan whenever its reference count reaches zero.
  */
-static dsm_handle *shareinput_Xslice_dsm_handle_ptr;
+dsm_handle *shareinput_Xslice_dsm_handle_ptr;
 static SharedFileSet *shareinput_Xslice_fileset;
 
 /*


### PR DESCRIPTION
---

### Change logs

Some extension need to use these variables, so it's not necessary to set them to static here.

### Why are the changes needed?

### Does this PR introduce any user-facing change?

### How was this patch tested?

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
