### PR TITLE
[AQUMV] Use view's TupleDesc to construct final columns.

### DIFF
--- a/src/backend/optimizer/README.cbdb.aqumv
+++ b/src/backend/optimizer/README.cbdb.aqumv
@@ -30,7 +30,7 @@ A materialized view(MV) could be use to compute a Query if:
 
 Vocabulary:
       origin_query: the SQL we want to query.
-      mv_query: for materialized view's corresponding query, the SELECT part of a Create Materialized View.
+      view_query:  the materialized view's corresponding query, SELECT part of Create Materialized View statement.
 
 Construct Rows
 --------------
@@ -39,7 +39,7 @@ If MV has all rows of query needed, it means that MV query's restrictions are lo
 For AQUMV_MVP0, we only do logistic transformation.
 All rewrites are on the Query tree, neither Equivalent Classes nor Restrictions are used.
 For a single relation:
-process mv_query and origin_query's WHERE part to set:
+process view_query and origin_query's WHERE part to set:
 mv_query_quals and origin_query_quals.
 
 example0:
@@ -134,14 +134,14 @@ mv5 has all rows {a = 1} and only have column 'a', but the query want additional
 We couldn't rewrite it by just adding the {b = 2} to MV as no equivalent b in MV relation.
       Wrong: SELECT a FROM mv5 WHERE b = 2;
 
-The algorithm behind that is: all quals's expression could be computed from a mv_query's target list.
+The algorithm behind that is: all quals's expression could be computed from a view_query's target list.
 That's what Construct Columns does.
 
 Construct Columns
 -----------------
 
 A MV could be a candidate if the query's target list and the post_quals could be computed form
-mv_query's target list and rewrite to expressions bases on MV relation's columns itself.
+view_query's target list and rewrite to expressions bases on MV relation's columns itself.
 
 example6:
       CREATE MATERIALIZED VIEW mv6 AS SELECT abs(c) as mc1, b as mc2 FROM t WHERE a = 1;
@@ -218,13 +218,13 @@ Let the planner decide the best one.
 
 AQUMV_MVP
 ---------
-Support SELECT FROM a single relation both for mv_query and the origin_query.
+Support SELECT FROM a single relation both for view_query and the origin_query.
 Below are not supported now:
-      Aggregation (on mv_query)
+      Aggregation (on view_query)
       Subquery
       Join
       Sublink
-      Group By/Grouping Sets/Rollup/Cube (on mv_query)
+      Group By/Grouping Sets/Rollup/Cube (on view_query)
       Window Functions
       CTE
       Distinct


### PR DESCRIPTION
We once used a SQL like: SELECT * FROM mv to fetch target materialized view's attributes, which is ineffective. 
We don't need to do a full palnner of that SQL,  use TupleDesc to fetch mv's attributes instead.

Authored-by: Zhang Mingli avamingli@gmail.com

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
