### PR TITLE
Add new hashdata am oid to RelationIsNonblockRelation

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -719,11 +719,11 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 		TRIGGER_FOR_ROW(tgtype) &&
 		!stmt->isconstraint)
 	{
-		if (TRIGGER_FOR_UPDATE(tgtype))
+		if (TRIGGER_FOR_UPDATE(tgtype) && TRIGGER_FOR_AFTER(tgtype))
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("ON UPDATE triggers are not supported on append-only tables")));
-		if (TRIGGER_FOR_DELETE(tgtype))
+		if (TRIGGER_FOR_DELETE(tgtype) && TRIGGER_FOR_AFTER(tgtype))
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("ON DELETE triggers are not supported on append-only tables")));

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -526,6 +526,7 @@ typedef struct ViewOptions
  * can't distinguish the PAX and renamed heap(heap_psql) in test `psql`.
  */
 #define PAX_AM_OID 7047
+#define HASHDATA_AM_OID 7015
 /*
  * CAUTION: this macro is a violation of the absraction that table AM and
  * index AM interfaces provide.  Use of this macro is discouraged.  If
@@ -542,7 +543,8 @@ typedef struct ViewOptions
  */
 #define RelationIsNonblockRelation(relation) \
 	(RelationIsAppendOptimized(relation) || \
-	 (relation)->rd_rel->relam == PAX_AM_OID)
+	 (relation)->rd_rel->relam == PAX_AM_OID || \
+	 (relation)->rd_rel->relam == HASHDATA_AM_OID)
 
 /*
  * RelationIsBitmapIndex


### PR DESCRIPTION
Add a new am oid to RelationIsNonblockRelation, so that the new storage
could access some specific code. The reason for disable update/delete
trigger is that the cost of random access to these storages is too high.
But only after trigger will call fetch api, so we should all before
trigger for delete/update.