### PR TITLE
Fix CREATE TYPE in namespace pg_ext_aux

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1654,6 +1654,10 @@ heap_create_with_catalog(const char *relname,
 	 * NAMEDATALEN and gets truncated. Then the name may same with other child
 	 * table's.
 	 *
+	 * Auxiliary relations in pg_ext_aux don't need array type. Relations in
+	 * pg_ext_aux are assumed simple relation, their array types are unexpected
+	 * to be used in the extension code.
+	 *
 	 * The below code is different from upstream since we preassign type
 	 * OID first on QD and use the name as key to retrieve the pre-assigned
 	 * OID from QE.
@@ -1666,7 +1670,10 @@ heap_create_with_catalog(const char *relname,
 		  relkind == RELKIND_AOBLOCKDIR ||
 		  relkind == RELKIND_AOVISIMAP ||
 		  relnamespace == PG_BITMAPINDEX_NAMESPACE ||
-		  relnamespace == PG_EXTAUX_NAMESPACE))
+		  (relnamespace == PG_EXTAUX_NAMESPACE &&
+		   (relkind == RELKIND_RELATION ||
+			relkind == RELKIND_VIEW ||
+			relkind == RELKIND_MATVIEW))))
 	{
 		/* OK, so pre-assign a type OID for the array type */
 		Oid			new_array_oid;

--- a/src/test/regress/expected/pg_ext_aux.out
+++ b/src/test/regress/expected/pg_ext_aux.out
@@ -1,0 +1,79 @@
+-- Test use of namespace pg_ext_aux
+-- Test 1: Create database object in pg_ext_aux should fail normally
+create table pg_ext_aux.extaux_t(a int, b int);
+ERROR:  permission denied to create "pg_ext_aux.extaux_t"
+DETAIL:  System catalog modifications are currently disallowed.
+create view pg_ext_aux.extaux_v as select oid, relname from pg_class;
+ERROR:  permission denied to create "pg_ext_aux.extaux_v"
+DETAIL:  System catalog modifications are currently disallowed.
+create materialized view pg_ext_aux.extaux_mv as select oid, relname from pg_class;
+ERROR:  permission denied to create "pg_ext_aux.extaux_mv"
+DETAIL:  System catalog modifications are currently disallowed.
+-- shell type is created successfully
+create type pg_ext_aux.extaux_shell_type;
+-- concreate type will fail
+create type pg_ext_aux.extaux_concreat_type AS (sum int, count int);
+ERROR:  permission denied to create "pg_ext_aux.extaux_concreat_type"
+DETAIL:  System catalog modifications are currently disallowed.
+-- create function will success
+create function pg_ext_aux.extaux_add1(i integer) returns integer AS $$
+begin
+  return i + 1;
+end;
+$$ language plpgsql;
+-- Test 2: Create database object in pg_ext_aux should success
+-- if allow_system_table_mods is on
+set allow_system_table_mods = on;
+create table pg_ext_aux.extaux_t(a int, b text);
+create view pg_ext_aux.extaux_v as select * from pg_ext_aux.extaux_t;
+create materialized view pg_ext_aux.extaux_mv as select * from pg_ext_aux.extaux_t;
+create type pg_ext_aux.extaux_concreat_type AS (sum int, count int);
+set allow_system_table_mods = off;
+-- Test 3: Check that the array type is not created
+-- these relations have its reltype, but have no array type
+select typname, typarray from pg_type where oid = (select reltype from pg_class where relname='extaux_t');
+ typname | typarray 
+---------+----------
+(0 rows)
+
+select typname, typarray from pg_type where oid = (select reltype from pg_class where relname='extaux_v');
+ typname | typarray 
+---------+----------
+(0 rows)
+
+select typname, typarray from pg_type where oid = (select reltype from pg_class where relname='extaux_mv');
+ typname | typarray 
+---------+----------
+(0 rows)
+
+-- Test 4: check function works
+select pg_ext_aux.extaux_add1(7);
+ extaux_add1 
+-------------
+           8
+(1 row)
+
+-- Test 5: Check that these relations are protected
+-- fail: should not allowed to insert by user
+insert into pg_ext_aux.extaux_t values(1,'hello');
+ERROR:  permission denied: "extaux_t" is a system catalog
+-- fail: should not allowed to refresh by user
+refresh materialized view pg_ext_aux.extaux_mv;
+ERROR:  cannot swap toast files by links for system catalogs (cluster.c:1424)
+-- fail: should not allow to be dropped by user
+drop view pg_ext_aux.extaux_v;
+ERROR:  permission denied: "extaux_v" is a system catalog
+drop materialized view pg_ext_aux.extaux_mv;
+ERROR:  permission denied: "extaux_mv" is a system catalog
+drop table pg_ext_aux.extaux_t;
+ERROR:  permission denied: "extaux_t" is a system catalog
+-- Test 6: type and functions may be dropped normally
+drop type pg_ext_aux.extaux_shell_type;
+drop type pg_ext_aux.extaux_concreat_type;
+drop function pg_ext_aux.extaux_add1(i integer);
+-- Clean up
+set allow_system_table_mods = on;
+drop view pg_ext_aux.extaux_v;
+drop materialized view pg_ext_aux.extaux_mv;
+drop table pg_ext_aux.extaux_t;
+reset allow_system_table_mods;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -15,6 +15,9 @@
 #   hitting max_connections limit on segments.
 #
 
+# test for builtin namespace pg_ext_aux
+test: pg_ext_aux
+
 test: gp_dispatch_keepalives
 
 # copy command

--- a/src/test/regress/sql/pg_ext_aux.sql
+++ b/src/test/regress/sql/pg_ext_aux.sql
@@ -1,0 +1,62 @@
+-- Test use of namespace pg_ext_aux
+
+-- Test 1: Create database object in pg_ext_aux should fail normally
+create table pg_ext_aux.extaux_t(a int, b int);
+create view pg_ext_aux.extaux_v as select oid, relname from pg_class;
+create materialized view pg_ext_aux.extaux_mv as select oid, relname from pg_class;
+
+-- shell type is created successfully
+create type pg_ext_aux.extaux_shell_type;
+-- concreate type will fail
+create type pg_ext_aux.extaux_concreat_type AS (sum int, count int);
+
+-- create function will success
+create function pg_ext_aux.extaux_add1(i integer) returns integer AS $$
+begin
+  return i + 1;
+end;
+$$ language plpgsql;
+
+
+-- Test 2: Create database object in pg_ext_aux should success
+-- if allow_system_table_mods is on
+set allow_system_table_mods = on;
+create table pg_ext_aux.extaux_t(a int, b text);
+create view pg_ext_aux.extaux_v as select * from pg_ext_aux.extaux_t;
+create materialized view pg_ext_aux.extaux_mv as select * from pg_ext_aux.extaux_t;
+create type pg_ext_aux.extaux_concreat_type AS (sum int, count int);
+set allow_system_table_mods = off;
+
+-- Test 3: Check that the array type is not created
+-- these relations have its reltype, but have no array type
+select typname, typarray from pg_type where oid = (select reltype from pg_class where relname='extaux_t');
+select typname, typarray from pg_type where oid = (select reltype from pg_class where relname='extaux_v');
+select typname, typarray from pg_type where oid = (select reltype from pg_class where relname='extaux_mv');
+
+-- Test 4: check function works
+select pg_ext_aux.extaux_add1(7);
+
+-- Test 5: Check that these relations are protected
+-- fail: should not allowed to insert by user
+insert into pg_ext_aux.extaux_t values(1,'hello');
+-- fail: should not allowed to refresh by user
+refresh materialized view pg_ext_aux.extaux_mv;
+
+-- fail: should not allow to be dropped by user
+drop view pg_ext_aux.extaux_v;
+drop materialized view pg_ext_aux.extaux_mv;
+drop table pg_ext_aux.extaux_t;
+
+-- Test 6: type and functions may be dropped normally
+drop type pg_ext_aux.extaux_shell_type;
+drop type pg_ext_aux.extaux_concreat_type;
+drop function pg_ext_aux.extaux_add1(i integer);
+
+
+-- Clean up
+set allow_system_table_mods = on;
+drop view pg_ext_aux.extaux_v;
+drop materialized view pg_ext_aux.extaux_mv;
+drop table pg_ext_aux.extaux_t;
+
+reset allow_system_table_mods;


### PR DESCRIPTION
Creating relation in namespace pg_ext_aux will not create the array type. The relations in pg_ext_aux are considered as auxiliary tables, used by some extensions. While creating type is different, the new type will also have its array type like other normal types.

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
