### PR TITLE
Revert #201 partially

### DIFF
--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -9,7 +9,6 @@ $(recurse)
 generate_greenplum_path_file:
 	mkdir -p $(DESTDIR)$(prefix)
 	unset LIBPATH; \
-	export WHICHPYTHON=$(PYTHON); \
 	bin/generate-greenplum-path.sh > $(DESTDIR)$(prefix)/greenplum_path.sh
 
 install: generate_greenplum_path_file

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 cat <<"EOF"
-#!/usr/bin/env bash
 if test -n "${ZSH_VERSION:-}"; then
     # zsh
     SCRIPT_PATH="${(%):-%x}"
@@ -27,13 +26,9 @@ else
 fi
 EOF
 
-cat <<EOF
-PYTHONBINDIR="$(dirname "${WHICHPYTHON}")"
-EOF
-
 cat <<"EOF"
 PYTHONPATH="${GPHOME}/lib/python"
-PATH="${GPHOME}/bin:${PYTHONBINDIR}:${PATH}"
+PATH="${GPHOME}/bin:${PATH}"
 LD_LIBRARY_PATH="${GPHOME}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
 if [ -e "${GPHOME}/etc/openssl.cnf" ]; then


### PR DESCRIPTION
Current greenplum_path.sh is a result of #201 to make greenplum_path.sh always using the Python during `./configure`. But it inadvertently changes user's `PATH`. This portion of #201 is reverted, and it should be fine if people all use `pip install --user` to install dependencies.