### PR TITLE
Move preloaded interconnect to the header file

### DIFF
--- a/src/backend/utils/init/miscinit.c
+++ b/src/backend/utils/init/miscinit.c
@@ -1891,7 +1891,7 @@ process_shared_preload_libraries(void)
 {
 	process_shared_preload_libraries_in_progress = true;
 
-	char* libraries = expand_shared_preload_libraries_string();
+	char *libraries = expand_shared_preload_libraries_string();
 	load_libraries(libraries,
 				   "shared_preload_libraries",
 				   false);
@@ -1899,12 +1899,6 @@ process_shared_preload_libraries(void)
 	{
 		pfree(libraries);
 	}
-
-#ifdef ENABLE_PRELOAD_IC_MODULE
-	load_libraries("interconnect",
-				   "preload interconnect module",
-				   false);
-#endif
 
 	process_shared_preload_libraries_in_progress = false;
 	process_shared_preload_libraries_done = true;

--- a/src/include/utils/process_shared_preload_libraries.h
+++ b/src/include/utils/process_shared_preload_libraries.h
@@ -1,0 +1,3 @@
+#ifdef ENABLE_PRELOAD_IC_MODULE
+  "interconnect",
+#endif


### PR DESCRIPTION
`interconnect` is expected to preload if the macro option ENABLE_PRELOAD_IC_MODULE is set. The header file
`process_shared_preload_libraries.h` is kept to save all builtin shared preloaded libraries.

This commit defines the `interconnect` preload in
`process_shared_preload_libraries.h` to minimize code diverge.


### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
