### PR TITLE
Add new callback 'scan_flags' for table access method

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -757,6 +757,12 @@ aoco_getnextslot(TableScanDesc scan, ScanDirection direction, TupleTableSlot *sl
 	return false;
 }
 
+static int
+aoco_scan_flags(Relation rel)
+{
+	return 0;
+}
+
 static Size
 aoco_parallelscan_estimate(Relation rel)
 {
@@ -2402,6 +2408,7 @@ static TableAmRoutine ao_column_methods = {
 	.scan_end = aoco_endscan,
 	.scan_rescan = aoco_rescan,
 	.scan_getnextslot = aoco_getnextslot,
+	.scan_flags = aoco_scan_flags,
 
 	.parallelscan_estimate = aoco_parallelscan_estimate,
 	.parallelscan_initialize = aoco_parallelscan_initialize,

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -1799,6 +1799,12 @@ appendonly_getnextslot(TableScanDesc scan, ScanDirection direction, TupleTableSl
 	return false;
 }
 
+int
+appendonly_scan_flags(Relation relation)
+{
+	return 0;
+}
+
 static void
 closeFetchSegmentFile(AppendOnlyFetchDesc aoFetchDesc)
 {

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -2345,6 +2345,7 @@ static const TableAmRoutine ao_row_methods = {
 	.scan_end = appendonly_endscan,
 	.scan_rescan = appendonly_rescan,
 	.scan_getnextslot = appendonly_getnextslot,
+	.scan_flags = appendonly_scan_flags,
 
 	.parallelscan_estimate = appendonly_parallelscan_estimate,
 	.parallelscan_initialize = appendonly_parallelscan_initialize,

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -1621,6 +1621,12 @@ heap_getnextslot_tidrange(TableScanDesc sscan, ScanDirection direction,
 	return true;
 }
 
+int
+heap_scan_flags(Relation relation)
+{
+	return 0;
+}
+
 /*
  *	heap_fetch		- retrieve tuple with given tid
  *

--- a/src/backend/access/heap/heapam_handler.c
+++ b/src/backend/access/heap/heapam_handler.c
@@ -2597,6 +2597,7 @@ static const TableAmRoutine heapam_methods = {
 
 	.scan_set_tidrange = heap_set_tidrange,
 	.scan_getnextslot_tidrange = heap_getnextslot_tidrange,
+	.scan_flags = heap_scan_flags,
 
 	.parallelscan_estimate = table_block_parallelscan_estimate,
 	.parallelscan_initialize = table_block_parallelscan_initialize,

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -135,6 +135,7 @@ extern void heap_set_tidrange(TableScanDesc sscan, ItemPointer mintid,
 extern bool heap_getnextslot_tidrange(TableScanDesc sscan,
 									  ScanDirection direction,
 									  TupleTableSlot *slot);
+extern int heap_scan_flags(Relation relation);
 extern bool heap_fetch(Relation relation, Snapshot snapshot,
 					   HeapTuple tuple, Buffer *userbuf);
 extern bool heap_fetch_extended(Relation relation, Snapshot snapshot,

--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -390,6 +390,13 @@ typedef struct TableAmRoutine
 											  ScanDirection direction,
 											  TupleTableSlot *slot);
 
+	/*
+	 * This callback is used to indicate what the AM can do, what features the
+	 * AM can support, return the flags represented the supported features of
+	 * scan.
+	 */
+	int			(*scan_flags) (Relation rel);
+
 	/* ------------------------------------------------------------------------
 	 * Parallel table scan related functions.
 	 * ------------------------------------------------------------------------

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -445,6 +445,7 @@ extern void appendonly_endscan(TableScanDesc scan);
 extern bool appendonly_getnextslot(TableScanDesc scan,
 								   ScanDirection direction,
 								   TupleTableSlot *slot);
+extern int appendonly_scan_flags(Relation relation);
 extern AppendOnlyFetchDesc appendonly_fetch_init(
 	Relation 	relation,
 	Snapshot    snapshot,


### PR DESCRIPTION
The table access method supports different features due to the different implementation, this callback is used to indicate what the AM can do, what features the AM can support.