### PR TITLE
Fix: redefined sm4 in pgcrypto and backend/crypto

### DIFF
--- a/contrib/pgcrypto/openssl_redirect.c
+++ b/contrib/pgcrypto/openssl_redirect.c
@@ -36,7 +36,7 @@ bool px_find_cipher_support_redirect(const char *name) {
         return true;
     }
 
-    if (strcmp("sm4-128-cbc", name) == 0) {
+    if (strcmp("sm4-128-ecb", name) == 0) {
         return true;
     }
     return false;

--- a/src/backend/crypto/Makefile
+++ b/src/backend/crypto/Makefile
@@ -14,7 +14,7 @@ include $(top_builddir)/src/Makefile.global
 
 OBJS = \
 	bufenc.o \
-	sm4.o \
+	sm4_ofb.o \
 	kmgr.o
 
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/crypto/bufenc.c
+++ b/src/backend/crypto/bufenc.c
@@ -19,7 +19,7 @@
 #include "access/gist.h"
 #include "access/xlog.h"
 #include "crypto/bufenc.h"
-#include "crypto/sm4.h"
+#include "crypto/sm4_ofb.h"
 #include "storage/bufpage.h"
 #include "storage/fd.h"
 #include "storage/shmem.h"
@@ -57,8 +57,8 @@ InitializeBufferEncryption(void)
 
 		BufDecCtx = ShmemInitStruct("sm4 encryption method decrypt ctx",
 												sizeof(sm4_ctx), &found);
-		sm4_setkey_enc((sm4_ctx *)BufEncCtx, (unsigned char *)key->key);
-		sm4_setkey_dec((sm4_ctx *)BufDecCtx, (unsigned char *)key->key);
+		sm4_ofb_setkey_enc((sm4_ctx *)BufEncCtx, (unsigned char *)key->key);
+		sm4_ofb_setkey_dec((sm4_ctx *)BufDecCtx, (unsigned char *)key->key);
 	}
 	else 
 	{

--- a/src/backend/crypto/sm4_ofb.c
+++ b/src/backend/crypto/sm4_ofb.c
@@ -1,6 +1,6 @@
 #include "postgres.h"
 #include <sys/param.h>
-#include "crypto/sm4.h"
+#include "crypto/sm4_ofb.h"
 
 static const uint8_t SM4_S[256] = {
     0xD6, 0x90, 0xE9, 0xFE, 0xCC, 0xE1, 0x3D, 0xB7, 0x16, 0xB6, 0x14, 0xC2,
@@ -368,13 +368,13 @@ void ossl_sm4_decrypt(const uint8_t *in, uint8_t *out, const SM4_KEY *ks)
     store_u32_be(B0, out + 12);
 }
 
-void sm4_setkey_enc(sm4_ctx *ctx, uint8_t* key)
+void sm4_ofb_setkey_enc(sm4_ctx *ctx, uint8_t* key)
 {
 	ossl_sm4_set_key(key, &ctx->rkey);
     ctx->encrypt = SM4_ENCRYPT;
 }
 
-void sm4_setkey_dec(sm4_ctx *ctx, uint8_t* key)
+void sm4_ofb_setkey_dec(sm4_ctx *ctx, uint8_t* key)
 {
 	ossl_sm4_set_key(key, &ctx->rkey);
     ctx->encrypt = SM4_DECRYPT;

--- a/src/include/crypto/sm4_ofb.h
+++ b/src/include/crypto/sm4_ofb.h
@@ -8,8 +8,8 @@
  *
  *-------------------------------------------------------------------------
  */
-#ifndef _SM4_H_
-#define _SM4_H_
+#ifndef _SM4_OFB_H_
+#define _SM4_OFB_H_
 #include "c.h"
 
 # define SM4_ENCRYPT     1
@@ -55,9 +55,9 @@ int ossl_sm4_set_key(const uint8_t *key, SM4_KEY *ks);
 void ossl_sm4_encrypt(const uint8_t *in, uint8_t *out, const SM4_KEY *ks);
 
 void ossl_sm4_decrypt(const uint8_t *in, uint8_t *out, const SM4_KEY *ks);
-void sm4_setkey_enc(sm4_ctx *ctx, uint8_t* key);
-void sm4_setkey_dec(sm4_ctx *ctx, uint8_t* key);
+void sm4_ofb_setkey_enc(sm4_ctx *ctx, uint8_t* key);
+void sm4_ofb_setkey_dec(sm4_ctx *ctx, uint8_t* key);
 int sm4_ofb_cipher(sm4_ctx *ctx, unsigned char *out,
                         const unsigned char *in, size_t input_len,
                         unsigned char ivec[16]);
-#endif /* _SM4_H_ */
+#endif /* _SM4_OFB_H_ */


### PR DESCRIPTION
<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

After the pgcrypto module supported sm4, the sm4-128-ofb mode was added in `backend/sm4.c`

This approach is very unclean. And the implementation of sm4 in pgcrypto is overwritten.



### Why are the changes needed?



### Does this PR introduce any user-facing change?



### How was this patch tested?



### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
