### PR TITLE
Fix: no need to do the qual-clause twice

### DIFF
--- a/src/backend/executor/execScan.c
+++ b/src/backend/executor/execScan.c
@@ -224,6 +224,15 @@ ExecScan(ScanState *node,
 		econtext->ecxt_scantuple = slot;
 
 		/*
+		 * reinit qual
+		 *
+		 * CBDB already support pushdown qual-clause.
+		 * If current qual-clause have been process in access method
+		 * Then ExprState inside PlanState should reset to NULL.
+		 */
+		qual = node->ps.qual;
+
+		/*
 		 * check that the current tuple satisfies the qual-clause
 		 *
 		 * check for non-null qual here to avoid a function call to ExecQual()


### PR DESCRIPTION
<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

CBDB already support pushdown qual-clause. If current qual-clause have been process in access method, Then ExprState inside PlanState should reset to NULL, In this time, `ExecScan` should not exec it again.

### Why are the changes needed?


### Does this PR introduce any user-facing change?



### How was this patch tested?



### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
