### PR TITLE
Feature: add batch size guc for vector and pax extension.

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -433,6 +433,9 @@ int  gp_predicate_pushdown_sample_rows;
 bool        enable_offload_entry_to_qe = false;
 bool enable_answer_query_using_materialized_views = false;
 
+/* vector and pax flags */
+int 		gp_batch_size = false;
+
 static const struct config_enum_entry gp_log_format_options[] = {
 	{"text", 0},
 	{"csv", 1},
@@ -4272,6 +4275,16 @@ struct config_int ConfigureNamesInt_gp[] =
 		&max_running_tasks,
 		5, 1, MAX_BACKENDS,
 		check_max_running_tasks, NULL, NULL
+	},
+
+	{
+		{"gp_batch_size", PGC_USERSET, CUSTOM_OPTIONS,
+			gettext_noop("vectorization executor row count handle in one batch"),
+			NULL,
+			GUC_GPDB_NEED_SYNC
+		},
+		&gp_batch_size,
+		16384, 0, 65536, NULL, NULL
 	},
 	
 	/* End-of-list marker */

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -626,6 +626,7 @@ extern bool gp_enable_global_deadlock_detector;
 
 extern bool gp_enable_predicate_pushdown;
 extern int  gp_predicate_pushdown_sample_rows;
+extern int  gp_batch_size;
 
 typedef enum
 {


### PR DESCRIPTION


### Change logs

add batch size for pax and vector extension.

### Why are the changes needed?

both pax and vector needs batch guc.

### Does this PR introduce any user-facing change?

no.

### How was this patch tested?

no.

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [x] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [x] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [x] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [x] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [x] Document changes.
- [x] Add tests for the change
- [x] Pass `make installcheck`
- [x] Pass `make -C src/test installcheck-cbdb-parallel`
- [x] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
