### PR TITLE
feature: Use amflags to support Column-oriented scanning of custom ta…

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -760,7 +760,7 @@ aoco_getnextslot(TableScanDesc scan, ScanDirection direction, TupleTableSlot *sl
 static uint32
 aoco_scan_flags(Relation rel)
 {
-	return 0;
+	return SCAN_SUPPORT_COLUMN_ORIENTED_SCAN;
 }
 
 static Size

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -974,7 +974,7 @@ use_physical_tlist(PlannerInfo *root, Path *path, int flags)
 	 * Using physical target list with column store will result in scanning all
 	 * column files, which will cause a significant performance degradation.
 	 */
-	if (AMHandlerIsAoCols(rel->amhandler))
+	if (rel->amflags & AMFLAG_HAS_COLUMN_ORIENTED_SCAN)
 		return false;
 
 	/*

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -491,6 +491,12 @@ get_relation_info(PlannerInfo *root, Oid relationObjectId, bool inhparent,
 		relation->rd_tableam->scan_getnextslot_tidrange != NULL)
 		rel->amflags |= AMFLAG_HAS_TID_RANGE;
 
+	/* Collect info about relation's store information, if it support column-oriented scan  */
+	if (relation->rd_tableam && relation->rd_tableam->scan_flags && 
+		(relation->rd_tableam->scan_flags(relation) & SCAN_SUPPORT_COLUMN_ORIENTED_SCAN)) {
+		rel->amflags |= AMFLAG_HAS_COLUMN_ORIENTED_SCAN;
+	}
+
 	/*
 	 * Collect info about relation's partitioning scheme, if any. Only
 	 * inheritance parents may be partitioned.

--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -41,6 +41,18 @@ struct TBMIterateResult;
 struct VacuumParams;
 struct ValidateIndexState;
 
+/**
+ * Flags represented the supported features of scan.
+ * 
+ * The first 8 bits are reserved for kernel expansion of some attributes,
+ * and the remaining 24 bits are reserved for custom tableam.
+ * 
+ * If you add a new flag, make sure the flag's bit is consecutive with
+ * the previous one.
+ * 
+*/
+#define SCAN_SUPPORT_COLUMN_ORIENTED_SCAN (1 << 0)  /* support column-oriented scanning*/
+
 /*
  * Bitmask values for the flags argument to the scan_begin callback.
  */

--- a/src/include/nodes/pathnodes.h
+++ b/src/include/nodes/pathnodes.h
@@ -823,6 +823,8 @@ static inline void planner_subplan_put_plan(struct PlannerInfo *root, SubPlan *s
 
 /* Bitmask of flags supported by table AMs */
 #define AMFLAG_HAS_TID_RANGE (1 << 0)
+/* Column-oriented scanning of flags supported by table AMs */
+#define AMFLAG_HAS_COLUMN_ORIENTED_SCAN (1 << 1)
 
 typedef enum RelOptKind
 {


### PR DESCRIPTION
<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs
For custom tableam, maybe it support column-oriented scanning, the postgres planner can no longer use whether am_handler is aocs table_am to decide whether only to add the columns required by the operator to the targetlist.

If table am supports column-oriented scanning, the flags returned by set_flags set the SCAN_SUPPORT_COLUMN_ORIENTED_SCAN bit.


### Why are the changes needed?

I hope that custom column storage can also scan only necessary columns, instead of only aocs table am support

### Does this PR introduce any user-facing change?

no

### How was this patch tested?


### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
