### PR TITLE
Fix: pgrx cannot find function after numeric change interface

### DIFF
--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -546,6 +546,51 @@ numeric_is_integral(Numeric num)
 	return (arg.ndigits == 0 || arg.ndigits <= arg.weight + 1);
 }
 
+
+/*
+ * numeric_is_nan() -
+ *
+ *	Is Numeric value a NaN?
+ */
+bool
+numeric_is_nan(Numeric num)
+{
+	return NUMERIC_IS_NAN(num);
+}
+
+/*
+ * numeric_digits() -
+ *
+ *	Output function for numeric's digits
+ */
+NumericDigit *
+numeric_digits(Numeric num)
+{
+	return NUMERIC_DIGITS(num);
+}
+
+/*
+ * numeric_len() -
+ *
+ *	Output size of digits in bytes
+ */
+int
+numeric_len(Numeric num)
+{
+	return NUMERIC_NDIGITS(num) * sizeof(NumericDigit);
+}
+
+/*
+ * numeric_is_inf() -
+ *
+ *	Is Numeric value an infinity?
+ */
+bool
+numeric_is_inf(Numeric num)
+{
+	return NUMERIC_IS_INF(num);
+}
+
 /*
  * numeric_maximum_size() -
  *

--- a/src/include/utils/numeric.h
+++ b/src/include/utils/numeric.h
@@ -343,6 +343,16 @@ extern float8 numeric_li_fraction(Numeric x, Numeric x0, Numeric x1,
 extern Numeric numeric_li_value(float8 f, Numeric y0, Numeric y1);
 
 /*
+ * Some of utility functions. which have same definition as the macro,
+ * but some of extension will these function rather than use the marco
+ * like `pgrx`.
+ */
+extern int16 *numeric_digits(Numeric num);
+extern int numeric_len(Numeric num);
+extern bool numeric_is_nan(Numeric num);
+extern bool numeric_is_inf(Numeric num);
+
+/*
  * Utility functions in numeric.c
  */
 int32		numeric_maximum_size(int32 typmod);


### PR DESCRIPTION

### Change logs

After CBDB public part of numeric defines, then `numeric_is_nan`/`numeric_is_inf` have been replace with macro `NUMERIC_IS_NAN`/`NUMERIC_IS_INF`.

But some of extension may not write by c/c++, then it can't direct call the macro `NUMERIC_IS_NAN`/`NUMERIC_IS_INF`. So current change add these function back.

### Why are the changes needed?

nope

### Does this PR introduce any user-facing change?

nope 

### How was this patch tested?

nope

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
