### PR TITLE
Disable dump pax tables in pg_dump

### DIFF
--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -383,6 +383,7 @@ typedef struct _tableInfo
 	char	   *partbound;		/* partition bound definition */
 	bool		needs_override; /* has GENERATED ALWAYS AS IDENTITY */
 	char	   *amname;			/* relation access method */
+	Oid			amoid;			/* relation access method oid */
 
 	/*
 	 * Stuff computed only for dumpable tables.


### PR DESCRIPTION
fix #ISSUE_Number

---

### Change logs

Pax is not working properly in `pg_dump/pg_restore`.

There are several problems:

1. The pax relative table in namespace `pg_ext_aux` won't be dump.
1. The table access method pax have not been setting in `pg_dump`.

Current change ignore pax table in `pg_dump`.

### Why are the changes needed?

nope

### Does this PR introduce any user-facing change?

nope

### How was this patch tested?

none

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
