### PR TITLE
Fix drop directory privilege check.

### DIFF
--- a/src/backend/catalog/storage_directory_table.c
+++ b/src/backend/catalog/storage_directory_table.c
@@ -94,11 +94,6 @@ DirectoryTableDropStorage(Relation rel)
 	tablespaceoid = spcform->oid;
 	tablespace_name = pstrdup(NameStr(((Form_pg_tablespace) GETSTRUCT(tuple))->spcname));
 
-	/* Must be tablespace owner */
-	if (!pg_tablespace_ownercheck(tablespaceoid, GetUserId()))
-		aclcheck_error(ACLCHECK_NOT_OWNER, OBJECT_TABLESPACE,
-					   tablespace_name);
-
 	table_endscan(scandesc);
 	table_close(spcrel, RowExclusiveLock);
 

--- a/src/test/modules/directory_table/.gitignore
+++ b/src/test/modules/directory_table/.gitignore
@@ -1,0 +1,2 @@
+# Generated subdirectories
+/tmp_check/

--- a/src/test/modules/directory_table/Makefile
+++ b/src/test/modules/directory_table/Makefile
@@ -1,0 +1,17 @@
+# src/test/modules/directory_table/Makefile
+
+MODULE = directory_table
+PGFILEDESC = "directory_table - Test DDL of manipulating directory table"
+
+TAP_TESTS = 1
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = src/test/modules/directory_table
+top_builddir = ../../../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/src/test/modules/directory_table/README
+++ b/src/test/modules/directory_table/README
@@ -1,0 +1,1 @@
+Test DDL of manipulating directory table

--- a/src/test/modules/directory_table/t/01_drop_directory_table.pl
+++ b/src/test/modules/directory_table/t/01_drop_directory_table.pl
@@ -1,0 +1,141 @@
+
+#  Copyright (c) 2024, Cloudberry Database, HashData Technology Limited.
+
+# Test drop directory table.
+#
+# This test can only run with Unix-domain sockets.
+
+use strict;
+use warnings;
+use PostgresNode;
+use TestLib;
+use Test::More;
+if (!$use_unix_sockets)
+{
+	plan skip_all =>
+	  "drop directory table tests cannot run without Unix-domain sockets";
+}
+else
+{
+	plan tests => 10;
+}
+
+# Delete pg_hba.conf from the given node, add a new entry to it
+# and then execute a reload to refresh it.
+sub reset_pg_hba
+{
+	my $node       = shift;
+	my $hba_method = shift;
+
+	unlink($node->data_dir . '/pg_hba.conf');
+	$node->append_conf('pg_hba.conf', "local all all $hba_method");
+	$node->reload;
+	return;
+}
+
+# Initialize primary node. Force UTF-8 encoding, so that we can use non-ASCII
+# characters in the passwords below.
+my $node = get_new_node('primary');
+my ($ret, $stdout, $stderr);
+$node->init(extra => [ '--locale=C', '--encoding=UTF8' ]);
+$node->append_conf('postgresql.conf', "log_connections = on\n");
+$node->start;
+
+# Create test directory table.
+$node->safe_psql(
+    'postgres',
+    "CREATE DIRECTORY TABLE test_dir1;
+CREATE DIRECTORY TABLE test_dir2;
+");
+
+# Create test roles.
+$node->safe_psql(
+	'postgres',
+	"SET client_encoding='utf8';
+CREATE USER test_user1;
+CREATE USER test_user2 SUPERUSER;
+");
+
+# Test CREATE DIRECTORY TABLE
+($ret, $stdout, $stderr) =
+$node->role_psql(
+    'test_user1',
+    'postgres',
+    "CREATE DIRECTORY TABLE test_dir3;"
+);
+is($ret, 0, 'create directory table succeed');
+
+($ret, $stdout, $stderr) =
+$node->role_psql(
+    'test_user2',
+    'postgres',
+    "CREATE DIRECTORY TABLE test_dir4;"
+);
+is($ret, 0, 'create directory table succeed');
+
+# Test DROP DIRECTORY TABLE
+($ret, $stdout, $stderr) =
+$node->role_psql(
+    'test_user1',
+    'postgres',
+    "DROP DIRECTORY TABLE test_dir1;"
+);
+is($ret, 3, 'user has no privileges to drop directory table');
+like(
+    $stderr,
+    qr/must be owner of directory table test_dir1/,
+    'expected error from user can not drop directory table'
+);
+
+($ret, $stdout, $stderr) =
+$node->role_psql(
+    'test_user2',
+    'postgres',
+    "DROP DIRECTORY TABLE test_dir2;"
+);
+is($ret, 0, 'drop directory table succeed');
+
+($ret, $stdout, $stderr) =
+$node->role_psql(
+    'test_user1',
+    'postgres',
+    "DROP DIRECTORY TABLE test_dir3;"
+);
+is($ret, 0, 'drop directory table succeed');
+
+($ret, $stdout, $stderr) =
+$node->role_psql(
+    'test_user1',
+    'postgres',
+    "DROP DIRECTORY TABLE test_dir4;"
+);
+is($ret, 3, 'user has no privileges to drop directory table');
+like(
+    $stderr,
+    qr/must be owner of directory table test_dir4/,
+    'expected error from user can not drop directory table'
+);
+
+($ret, $stdout, $stderr) =
+$node->role_psql(
+    'test_user2',
+    'postgres',
+    "DROP DIRECTORY TABLE test_dir4;"
+);
+is($ret, 0, 'drop directory table succeed');
+
+($ret, $stdout, $stderr) =
+$node->role_psql(
+    'test_user2',
+    'postgres',
+    "DROP DIRECTORY TABLE test_dir1;"
+);
+is($ret, 0, 'drop directory table succeed');
+
+# cleanup
+reset_pg_hba($node, 'trust');
+$node->safe_psql(
+    'postgres',
+    "DROP USER test_user1;
+    DROP USER test_user2;
+");


### PR DESCRIPTION
Now, when we drop directory table we will check whether current user has tablespace's privilege which is not reasonable. In this commit, we will check directory table's privilege in drop directory table.

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
