### PR TITLE
Fix motion toast error.

### DIFF
--- a/src/backend/cdb/motion/tupser.c
+++ b/src/backend/cdb/motion/tupser.c
@@ -412,7 +412,11 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 	{
 		Form_pg_attribute attr = TupleDescAttr(slot->tts_tupleDescriptor, i);
 
-		if (!attr->attisdropped && attr->attlen == -1 && !slot->tts_isnull[i])
+		/*
+		 * Cannot access slot->tts_isnull before invoking slot_getallattrs.
+		 * See Github Issue 16906.
+		 */
+		if (!attr->attisdropped && attr->attlen == -1)
 		{
 			hasExternalAttr = true;
 			break;

--- a/src/test/regress/expected/toast.out
+++ b/src/test/regress/expected/toast.out
@@ -180,3 +180,19 @@ SELECT encode(substring(a from 521*26+1 for 26), 'escape') FROM toast_chunk_test
  abcdefghijklmnopqrstuvwxyz
 (1 row)
 
+-- Test for Github Issue 16906
+create table t_16906(a int, b text) distributed by(a);
+-- Insert two rows and make sure they are in the same segment (same dist key)
+-- the 1st row's column b must be NULL;
+-- the 2nd row's column b must be a long string even after toast compression
+-- for details please refer to the issue page.
+insert into t_16906 values(1, null);
+insert into t_16906 values(1, randomtext(10240));
+-- Don't want actually fetch all data just need to test
+-- it does not hit assert fail or error. Using explain
+-- analyze might introduce a new ansfile for ORCA so here
+-- I decide to use \o.
+\o /tmp/t_16906.tmp
+select * from t_16906;
+\o
+drop table t_16906;


### PR DESCRIPTION
slot->tts_isnull cannot be read before invoking slot_getallattrs.

Fix Github Issue 16906.

Authored-by: wenxing.yaun <wenxing.yuan@esgyn.cn>

---

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
