### PR TITLE
PendingDelete: expand the pending deletes interface

### DIFF
--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -41,33 +41,6 @@
 /* GUC variables */
 int			wal_skip_threshold = 2048;	/* in kilobytes */
 
-/*
- * We keep a list of all relations (represented as RelFileNode values)
- * that have been created or deleted in the current transaction.  When
- * a relation is created, we create the physical file immediately, but
- * remember it so that we can delete the file again if the current
- * transaction is aborted.  Conversely, a deletion request is NOT
- * executed immediately, but is just entered in the list.  When and if
- * the transaction commits, we can delete the physical file.
- *
- * To handle subtransactions, every entry is marked with its transaction
- * nesting level.  At subtransaction commit, we reassign the subtransaction's
- * entries to the parent nesting level.  At subtransaction abort, we can
- * immediately execute the abort-time actions for all entries of the current
- * nesting level.
- *
- * NOTE: the list is kept in TopMemoryContext to be sure it won't disappear
- * unbetimes.  It'd probably be OK to keep it in TopTransactionContext,
- * but I'm being paranoid.
- */
-
-typedef struct PendingRelDelete
-{
-	RelFileNodePendingDelete relnode;		/* relation that may need to be deleted */
-	bool		atCommit;		/* T=delete at commit; F=delete at abort */
-	int			nestLevel;		/* xact nesting level of request */
-	struct PendingRelDelete *next;	/* linked-list link */
-} PendingRelDelete;
 
 typedef struct PendingRelSync
 {
@@ -77,6 +50,38 @@ typedef struct PendingRelSync
 
 static PendingRelDelete *pendingDeletes = NULL; /* head of linked list */
 HTAB	   *pendingSyncHash = NULL;
+
+
+static
+void
+StoargeDestroyPendingRelDelete(PendingRelDelete *reldelete)
+{
+	pfree(reldelete);
+}
+
+static
+void
+StorageDoPendingRelDelete(PendingRelDelete *delete)
+{
+	SMgrRelation srel;
+
+	/*
+	 * GPDB: backend can only be TempRelBackendId or InvalidBackendId for a
+	 * given relfile since we don't tie temp relations to their backends.
+	 */
+	srel = smgropen(delete->relnode.node,
+					delete->relnode.isTempRelation ?
+					TempRelBackendId : InvalidBackendId,
+					delete->relnode.smgr_which, NULL);
+	smgrdounlinkall(&srel, 1, false);
+	smgrclose(srel);
+}
+
+struct PendingRelDeleteAction storage_pending_rel_deletes_action = {
+	.flags = PENDING_REL_DELETE_NEED_PRESERVE | PENDING_REL_DELETE_NEED_XLOG | PENDING_REL_DELETE_NEED_SYNC,
+	.destroy_pending_rel_delete = StoargeDestroyPendingRelDelete,
+	.do_pending_rel_delete = StorageDoPendingRelDelete
+};
 
 
 /*
@@ -160,8 +165,8 @@ RelationCreateStorage(RelFileNode rnode, char relpersistence, SMgrImpl smgr_whic
 	pending->atCommit = false;	/* delete if abort */
 	pending->nestLevel = GetCurrentTransactionNestLevel();
 	pending->relnode.smgr_which = smgr_which;
-	pending->next = pendingDeletes;
-	pendingDeletes = pending;
+	pending->action = &storage_pending_rel_deletes_action;
+	RegisterPendingDelete(pending);
 
 	if (relpersistence == RELPERSISTENCE_PERMANENT && !XLogIsNeeded())
 	{
@@ -210,8 +215,8 @@ RelationDropStorage(Relation rel)
 	pending->nestLevel = GetCurrentTransactionNestLevel();
 	pending->relnode.smgr_which =
 		RelationIsAppendOptimized(rel) ? SMGR_AO : SMGR_MD;
-	pending->next = pendingDeletes;
-	pendingDeletes = pending;
+	pending->action = &storage_pending_rel_deletes_action;
+	RegisterPendingDelete(pending);
 
 	/*
 	 * NOTE: if the relation was created in this transaction, it will now be
@@ -254,6 +259,11 @@ RelationPreserveStorage(RelFileNode rnode, bool atCommit)
 	for (pending = pendingDeletes; pending != NULL; pending = next)
 	{
 		next = pending->next;
+		Assert(pending->action);
+		if (!(pending->action->flags & PENDING_REL_DELETE_NEED_PRESERVE)) {
+			continue;
+		}
+
 		if (RelFileNodeEquals(rnode, pending->relnode.node)
 			&& pending->atCommit == atCommit)
 		{
@@ -337,13 +347,13 @@ RelationTruncate(Relation rel, BlockNumber nblocks)
 	 * is in progress.
 	 *
 	 * The truncation operation might drop buffers that the checkpoint
-	 * otherwise would have flushed. If it does, then it's essential that
-	 * the files actually get truncated on disk before the checkpoint record
-	 * is written. Otherwise, if reply begins from that checkpoint, the
+	 * otherwise would have flushed. If it does, then it's essential that the
+	 * files actually get truncated on disk before the checkpoint record is
+	 * written. Otherwise, if reply begins from that checkpoint, the
 	 * to-be-truncated blocks might still exist on disk but have older
-	 * contents than expected, which can cause replay to fail. It's OK for
-	 * the blocks to not exist on disk at all, but not for them to have the
-	 * wrong contents.
+	 * contents than expected, which can cause replay to fail. It's OK for the
+	 * blocks to not exist on disk at all, but not for them to have the wrong
+	 * contents.
 	 */
 	Assert(!MyProc->delayChkptEnd);
 	MyProc->delayChkptEnd = true;
@@ -583,11 +593,12 @@ SerializePendingSyncs(Size maxSize, char *startAddress)
 		(void) hash_search(tmphash, &sync->rnode, HASH_ENTER, NULL);
 
 	/* remove deleted rnodes */
-	for (delete = pendingDeletes; delete != NULL; delete = delete->next)
-		if (delete->atCommit)
+	for (delete = pendingDeletes; delete != NULL; delete = delete->next) {
+		Assert(delete->action);
+		if (delete->atCommit && (delete->action->flags & PENDING_REL_DELETE_NEED_SYNC))
 			(void) hash_search(tmphash, (void *) &delete->relnode,
 							   HASH_REMOVE, NULL);
-
+	}
 	hash_seq_init(&scan, tmphash);
 	while ((src = (RelFileNode *) hash_seq_search(&scan)))
 		*dest++ = *src;
@@ -616,6 +627,15 @@ RestorePendingSyncs(char *startAddress)
 		AddPendingSync(rnode);
 }
 
+void
+RegisterPendingDelete(struct PendingRelDelete *delete)
+{
+	Assert(delete);
+	Assert(delete->action);
+	delete->next = pendingDeletes;
+	pendingDeletes = delete;
+}
+
 /*
  *	smgrDoPendingDeletes() -- Take care of relation deletes at end of xact.
  *
@@ -634,11 +654,6 @@ smgrDoPendingDeletes(bool isCommit)
 	PendingRelDelete *pending;
 	PendingRelDelete *prev;
 	PendingRelDelete *next;
-	int			nrels = 0,
-				maxrels = 0;
-	SMgrRelation *srels = NULL;
-
-	UFileDoDeletesActions(isCommit);
 
 	prev = NULL;
 	for (pending = pendingDeletes; pending != NULL; pending = next)
@@ -657,45 +672,20 @@ smgrDoPendingDeletes(bool isCommit)
 			else
 				pendingDeletes = next;
 			/* do deletion if called for */
+
 			if (pending->atCommit == isCommit)
 			{
-				SMgrRelation srel;
-				/* GPDB: backend can only be TempRelBackendId or
-				 * InvalidBackendId for a given relfile since we don't tie temp
-				 * relations to their backends. */
-				srel = smgropen(pending->relnode.node,
-								pending->relnode.isTempRelation ?
-								TempRelBackendId : InvalidBackendId,
-								pending->relnode.smgr_which, NULL);
-
-				/* allocate the initial array, or extend it, if needed */
-				if (maxrels == 0)
-				{
-					maxrels = 8;
-					srels = palloc(sizeof(SMgrRelation) * maxrels);
-				}
-				else if (maxrels <= nrels)
-				{
-					maxrels *= 2;
-					srels = repalloc(srels, sizeof(SMgrRelation) * maxrels);
-				}
-
-				srels[nrels++] = srel;
+				Assert(pending->action);
+				Assert(pending->action->do_pending_rel_delete);
+				pending->action->do_pending_rel_delete(pending);
 			}
+
 			/* must explicitly free the list entry */
-			pfree(pending);
+			Assert(pending->action);
+			Assert(pending->action->destroy_pending_rel_delete);
+			pending->action->destroy_pending_rel_delete(pending);
 			/* prev does not change */
 		}
-	}
-
-	if (nrels > 0)
-	{
-		smgrdounlinkall(srels, nrels, false);
-
-		for (int i = 0; i < nrels; i++)
-			smgrclose(srels[i]);
-
-		pfree(srels);
 	}
 }
 
@@ -734,11 +724,12 @@ smgrDoPendingSyncs(bool isCommit, bool isParallelWorker)
 	}
 
 	/* Skip syncing nodes that smgrDoPendingDeletes() will delete. */
-	for (pending = pendingDeletes; pending != NULL; pending = pending->next)
-		if (pending->atCommit)
+	for (pending = pendingDeletes; pending != NULL; pending = pending->next) {
+		Assert(pending->action);
+		if (pending->atCommit && (pending->action->flags & PENDING_REL_DELETE_NEED_SYNC))
 			(void) hash_search(pendingSyncHash, (void *) &pending->relnode,
 							   HASH_REMOVE, NULL);
-
+	}
 	hash_seq_init(&scan, pendingSyncHash);
 	while ((pendingsync = (PendingRelSync *) hash_seq_search(&scan)))
 	{
@@ -872,6 +863,12 @@ smgrGetPendingDeletes(bool forCommit, RelFileNodePendingDelete **ptr)
 	nrels = 0;
 	for (pending = pendingDeletes; pending != NULL; pending = pending->next)
 	{
+		Assert(pending->action);
+		if (!(pending->action->flags & PENDING_REL_DELETE_NEED_XLOG)) {
+			/* should not reocrd xlog expect pg relation */
+			continue;
+		}
+
 		if (pending->nestLevel >= nestLevel && pending->atCommit == forCommit
 			/*
 			 * Cloudberry allows transactions that access temporary tables to be
@@ -890,6 +887,11 @@ smgrGetPendingDeletes(bool forCommit, RelFileNodePendingDelete **ptr)
 	*ptr = rptr;
 	for (pending = pendingDeletes; pending != NULL; pending = pending->next)
 	{
+		Assert(pending->action);
+		if (!(pending->action->flags & PENDING_REL_DELETE_NEED_XLOG)) {
+			continue;
+		}
+
 		if (pending->nestLevel >= nestLevel && pending->atCommit == forCommit
 			/*
 			 * Keep this loop condition identical to above
@@ -903,6 +905,7 @@ smgrGetPendingDeletes(bool forCommit, RelFileNodePendingDelete **ptr)
 	}
 	return nrels;
 }
+
 /*
  *	PostPrepare_smgr -- Clean up after a successful PREPARE
  *
@@ -921,7 +924,9 @@ PostPrepare_smgr(void)
 		next = pending->next;
 		pendingDeletes = next;
 		/* must explicitly free the list entry */
-		pfree(pending);
+		Assert(pending->action);
+		Assert(pending->action->destroy_pending_rel_delete);
+		pending->action->destroy_pending_rel_delete(pending);
 	}
 }
 
@@ -935,8 +940,6 @@ AtSubCommit_smgr(void)
 {
 	int			nestLevel = GetCurrentTransactionNestLevel();
 	PendingRelDelete *pending;
-
-	UFileAtSubCommitSmgr();
 
 	for (pending = pendingDeletes; pending != NULL; pending = pending->next)
 	{
@@ -955,7 +958,6 @@ AtSubCommit_smgr(void)
 void
 AtSubAbort_smgr(void)
 {
-	UFileAtSubAbortSmgr();
 	smgrDoPendingDeletes(false);
 }
 

--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -497,7 +497,6 @@ RelationCopyStorage(SMgrRelation src, SMgrRelation dst,
 							relpathbackend(src->smgr_rnode.node,
 										   src->smgr_rnode.backend,
 										   forkNum))));
-
 		/*
 		 * WAL-log the copied page. Unfortunately we don't know what kind of a
 		 * page this is, so we have to log the full page including any unused
@@ -675,7 +674,6 @@ smgrDoPendingDeletes(bool isCommit)
 			else
 				pendingDeletes = next;
 			/* do deletion if called for */
-
 			if (pending->atCommit == isCommit)
 			{
 				Assert(pending->action);

--- a/src/backend/catalog/storage_directory_table.c
+++ b/src/backend/catalog/storage_directory_table.c
@@ -81,7 +81,7 @@ UfileDoPendingRelDelete(PendingRelDelete *reldelete)
 }
 
 struct PendingRelDeleteAction ufile_pending_rel_deletes_action = {
-	.flags = PENDING_REL_DELETE_NONE_FLAG,
+	.flags = PENDING_REL_DELETE_DEFAULT_FLAG,
 	.destroy_pending_rel_delete = UfileDestroyPendingRelDelete,
 	.do_pending_rel_delete = UfileDoPendingRelDelete
 };
@@ -131,15 +131,6 @@ DirectoryTableDropStorage(Relation rel)
 	filePath = psprintf("%s", dirTable->location);
 
 	UFileAddPendingDelete(rel, dirTable->spcId, filePath, true);
-
-	/*
-	 * NOTE: if the relation was created in this transaction, it will now be
-	 * present in the pending-delete list twice, once with atCommit true and
-	 * once with atCommit false.  We could instead remove the existing list
-	 * entry and delete the physical file immediately, but for now I'll keep
-	 * the logic simple.
-	 */
-	UFileUnlink(dirTable->spcId, filePath);
 
 	pfree(filePath);
 }

--- a/src/backend/catalog/storage_directory_table.c
+++ b/src/backend/catalog/storage_directory_table.c
@@ -19,6 +19,7 @@
 #include "access/xact.h"
 #include "catalog/pg_directory_table.h"
 #include "catalog/pg_tablespace.h"
+#include "catalog/storage.h"
 #include "catalog/storage_directory_table.h"
 #include "storage/smgr.h"
 #include "storage/ufile.h"
@@ -28,45 +29,75 @@
 #include "cdb/cdbvars.h"
 
 /*
- * TODO: Redo pending delete
+ * TODO: support ufile pending delete xlog
  *
- * We do not support deleteing files during WAL redo, this is because deleting
- * files requires a connection to object storage system. In order to establish
- * the connection to the object storage, we need to access the catalog table to
- * retrieve the connection configuration info, which is impossible during WAL
- * redo.
+ * Ufile do not support deleteing files during WAL redo, two of reason:
+ *
+ * 1. deleting files requires a connection to object storage system.
+ * In order to establish the connection to the object storage, we
+ * need to access the catalog table to retrieve the connection
+ * configuration info, which is impossible during WAL redo.
+ *
+ * 2. no custom xlog entry support.
+ * Custom WAL Resource Managers are immature and not reflected in CBDB.
+ *
  */
-
 typedef struct UFileNodePendingDelete
 {
-	char  relkind;
-	Oid   spcId;			/* directory table needs an extra tabpespace */
-	char *relativePath;
-} UFileNodePendingDelete;
+	char		relkind;
+	Oid			spcId;			/* directory table needs an extra tabpespace */
+	char	   *relativePath;
+}			UFileNodePendingDelete;
 
 typedef struct PendingRelDeleteUFile
 {
-	UFileNodePendingDelete filenode;		/* relation that may need to be deleted */
-	bool		atCommit;		/* T=delete at commit; F=delete at abort */
-	int			nestLevel;		/* xact nesting level of request */
-	struct PendingRelDeleteUFile *next;		/* linked-list link */
-} PendingRelDeleteUFile;
+	PendingRelDelete reldelete; /* base pending delete */
+	UFileNodePendingDelete filenode;	/* relation that may need to be
+										 * deleted */
+}			PendingRelDeleteUFile;
 
-static PendingRelDeleteUFile *pendingDeleteUFiles = NULL; /* head of linked list */
+
+static void
+UfileDestroyPendingRelDelete(PendingRelDelete *reldelete)
+{
+	PendingRelDeleteUFile *ufiledelete;
+
+	Assert(reldelete);
+	ufiledelete = (PendingRelDeleteUFile *) reldelete;
+
+	pfree(ufiledelete->filenode.relativePath);
+	pfree(ufiledelete);
+}
+
+static void
+UfileDoPendingRelDelete(PendingRelDelete *reldelete)
+{
+	PendingRelDeleteUFile *ufiledelete;
+
+	Assert(reldelete);
+	ufiledelete = (PendingRelDeleteUFile *) reldelete;
+
+	UFileUnlink(ufiledelete->filenode.spcId, ufiledelete->filenode.relativePath);
+}
+
+struct PendingRelDeleteAction ufile_pending_rel_deletes_action = {
+	.flags = PENDING_REL_DELETE_NONE_FLAG,
+	.destroy_pending_rel_delete = UfileDestroyPendingRelDelete,
+	.do_pending_rel_delete = UfileDoPendingRelDelete
+};
 
 void
 DirectoryTableDropStorage(Relation rel)
 {
-	char *filePath;
+	char	   *filePath;
 	DirectoryTable *dirTable;
-	PendingRelDeleteUFile *pending;
 	TableScanDesc scandesc;
 	Relation	spcrel;
 	HeapTuple	tuple;
 	Form_pg_tablespace spcform;
 	ScanKeyData entry[1];
 	Oid			tablespaceoid;
-	char 	   *tablespace_name;
+	char	   *tablespace_name;
 
 	dirTable = GetDirectoryTable(RelationGetRelid(rel));
 
@@ -85,9 +116,9 @@ DirectoryTableDropStorage(Relation rel)
 	if (!HeapTupleIsValid(tuple))
 	{
 		ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_OBJECT),
-					 errmsg("tablespace \"%d\" does not exist",
-							dirTable->spcId)));
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("tablespace \"%d\" does not exist",
+						dirTable->spcId)));
 	}
 
 	spcform = (Form_pg_tablespace) GETSTRUCT(tuple);
@@ -99,35 +130,13 @@ DirectoryTableDropStorage(Relation rel)
 
 	filePath = psprintf("%s", dirTable->location);
 
-	/* Add the relation to the list of stuff to delete at commit */
-	pending = (PendingRelDeleteUFile *)
-		MemoryContextAlloc(TopMemoryContext, sizeof(PendingRelDeleteUFile));
-	pending->filenode.relkind = rel->rd_rel->relkind;
-	pending->filenode.relativePath = MemoryContextStrdup(TopMemoryContext, filePath);
-	pending->filenode.spcId = dirTable->spcId;
-
-	pending->atCommit = true;	/* delete if commit */
-	pending->nestLevel = GetCurrentTransactionNestLevel();
-	pending->next = pendingDeleteUFiles;
-
-	pendingDeleteUFiles = pending;
+	UFileAddPendingDelete(rel, dirTable->spcId, filePath, true);
 
 	pfree(filePath);
-
-	/*
-	 * Make sure the connection to the corresponding tablespace has
-	 * been cached.
-	 *
-	 * UFileDoDeletesActions->UFileUnlink is called outside of the
-	 * transaction, if we don't establish a connection here. we may
-	 * face the issus of accessing the catalog outside of the
-	 * transaction.
-	 */
-	forceCacheUFileResource(dirTable->spcId);
 }
 
 void
-UFileAddCreatePendingEntry(Relation rel, Oid spcId, char *relativePath)
+UFileAddPendingDelete(Relation rel, Oid spcId, char *relativePath, bool atCommit)
 {
 	PendingRelDeleteUFile *pending;
 
@@ -138,98 +147,18 @@ UFileAddCreatePendingEntry(Relation rel, Oid spcId, char *relativePath)
 	pending->filenode.relativePath = MemoryContextStrdup(TopMemoryContext, relativePath);
 	pending->filenode.spcId = spcId;
 
-	pending->atCommit = false;	/* delete if abort */
-	pending->nestLevel = GetCurrentTransactionNestLevel();
-	pending->next = pendingDeleteUFiles;
+	pending->reldelete.atCommit = atCommit; /* delete if abort */
+	pending->reldelete.nestLevel = GetCurrentTransactionNestLevel();
 
-	pendingDeleteUFiles = pending;
+	pending->reldelete.relnode.node = rel->rd_node;
+	pending->reldelete.relnode.isTempRelation = rel->rd_backend == TempRelBackendId;
+	pending->reldelete.relnode.smgr_which = SMGR_INVALID;
 
-	/*
-	 * Make sure the spccache to the corresponding tablespace has
-	 * been cached.
-	 */
-	forceCacheUFileResource(spcId);
-}
-
-void
-UFileAddDeletePendingEntry(Relation rel, Oid spcId, char *relativePath)
-{
-	PendingRelDeleteUFile *pending;
-
-	/* Add the relation to the list of stuff to delete at abort */
-	pending = (PendingRelDeleteUFile *)
-		MemoryContextAlloc(TopMemoryContext, sizeof(PendingRelDeleteUFile));
-	pending->filenode.relkind = rel->rd_rel->relkind;
-	pending->filenode.relativePath = MemoryContextStrdup(TopMemoryContext, relativePath);
-	pending->filenode.spcId = spcId;
-
-	pending->atCommit = true;	/* delete if commit */
-	pending->nestLevel = GetCurrentTransactionNestLevel();
-	pending->next = pendingDeleteUFiles;
-
-	pendingDeleteUFiles = pending;
+	pending->reldelete.action = &ufile_pending_rel_deletes_action;
+	RegisterPendingDelete(&pending->reldelete);
 
 	/*
-	 * Make sure the spccache to the corresponding tablespace has
-	 * been cached.
+	 * Make sure the spccache to the corresponding tablespace has been cached.
 	 */
 	forceCacheUFileResource(spcId);
-}
-
-void
-UFileDoDeletesActions(bool isCommit)
-{
-	int nestLevel = GetCurrentTransactionNestLevel();
-	PendingRelDeleteUFile *pending;
-	PendingRelDeleteUFile *prev;
-	PendingRelDeleteUFile *next;
-
-	prev = NULL;
-	for (pending = pendingDeleteUFiles; pending != NULL; pending = next)
-	{
-		next = pending->next;
-		if (pending->nestLevel < nestLevel)
-		{
-			/* outer-level entries should not be processed yet */
-			prev = pending;
-		}
-		else
-		{
-			/* unlink list entry first, so we don't retry on failure */
-			if (prev)
-				prev->next = next;
-			else
-				pendingDeleteUFiles = next;
-
-			/* do deletion if called for */
-			if (pending->atCommit == isCommit)
-				UFileUnlink(pending->filenode.spcId, pending->filenode.relativePath);
-
-			/* must explicitly free the list entry */
-			if (pending->filenode.relativePath)
-				pfree(pending->filenode.relativePath);
-
-			pfree(pending);
-			/* prev does not change */
-		}
-	}
-}
-
-void
-UFileAtSubCommitSmgr(void)
-{
-	int	nestLevel = GetCurrentTransactionNestLevel();
-	PendingRelDeleteUFile *pending;
-
-	for (pending = pendingDeleteUFiles; pending != NULL; pending = pending->next)
-	{
-		if (pending->nestLevel >= nestLevel)
-			pending->nestLevel = nestLevel - 1;
-	}
-}
-
-void
-UFileAtSubAbortSmgr(void)
-{
-	UFileDoDeletesActions(false);
 }

--- a/src/backend/catalog/storage_directory_table.c
+++ b/src/backend/catalog/storage_directory_table.c
@@ -132,6 +132,15 @@ DirectoryTableDropStorage(Relation rel)
 
 	UFileAddPendingDelete(rel, dirTable->spcId, filePath, true);
 
+	/*
+	 * NOTE: if the relation was created in this transaction, it will now be
+	 * present in the pending-delete list twice, once with atCommit true and
+	 * once with atCommit false.  We could instead remove the existing list
+	 * entry and delete the physical file immediately, but for now I'll keep
+	 * the logic simple.
+	 */
+	UFileUnlink(dirTable->spcId, filePath);
+
 	pfree(filePath);
 }
 

--- a/src/backend/commands/copyfrom.c
+++ b/src/backend/commands/copyfrom.c
@@ -1132,7 +1132,7 @@ CopyFromDirectoryTable(CopyFromState cstate)
 						 	 errmsg("failed to open file \"%s\": %s", orgiFileName, errorMessage)));
 
 			/* Delete uploaded file when the transaction fails */
-			UFileAddCreatePendingEntry(cstate->rel, dirTable->spcId, orgiFileName);
+			UFileAddPendingDelete(cstate->rel, dirTable->spcId, orgiFileName, false);
 
 			file_buf = TextDatumGetCString(myslot->tts_values[5]);
 			decode_file_len = strlen(file_buf);

--- a/src/backend/commands/dirtablecmds.c
+++ b/src/backend/commands/dirtablecmds.c
@@ -392,7 +392,7 @@ remove_file_segment(PG_FUNCTION_ARGS)
 	{
 		CatalogTupleDelete(relation, &tuple->t_self);
 		fullPathName = psprintf("%s/%s", dirTable->location, relativePath);
-		UFileAddDeletePendingEntry(relation, dirTable->spcId, fullPathName);
+		UFileAddPendingDelete(relation, dirTable->spcId, fullPathName, true);
 		exist = true;
 	}
 

--- a/src/include/catalog/storage.h
+++ b/src/include/catalog/storage.h
@@ -23,6 +23,68 @@
 /* GUC variables */
 extern int	wal_skip_threshold;
 
+/*
+ * We keep a list of all relations (represented as RelFileNode values)
+ * that have been created or deleted in the current transaction.  When
+ * a relation is created, we create the physical file immediately, but
+ * remember it so that we can delete the file again if the current
+ * transaction is aborted.  Conversely, a deletion request is NOT
+ * executed immediately, but is just entered in the list.  When and if
+ * the transaction commits, we can delete the physical file.
+ *
+ * To handle subtransactions, every entry is marked with its transaction
+ * nesting level.  At subtransaction commit, we reassign the subtransaction's
+ * entries to the parent nesting level.  At subtransaction abort, we can
+ * immediately execute the abort-time actions for all entries of the current
+ * nesting level.
+ *
+ * NOTE: the list is kept in TopMemoryContext to be sure it won't disappear
+ * unbetimes.  It'd probably be OK to keep it in TopTransactionContext,
+ * but I'm being paranoid.
+ */
+struct PendingRelDeleteAction;
+typedef struct PendingRelDelete
+{
+	struct PendingRelDeleteAction *action;	/* The action is to do pending
+											 * delete */
+	RelFileNodePendingDelete relnode;	/* relation that may need to be
+										 * deleted */
+	bool		atCommit;		/* T=delete at commit; F=delete at abort */
+	int			nestLevel;		/* xact nesting level of request */
+
+	struct PendingRelDelete *next;	/* linked-list link */
+} PendingRelDelete;
+
+/*
+ * functions used to pending delete callbacks
+ *
+ * Notice that: no xlog generate in these interface.
+ * also make sure that NO register same pending delete
+ * into smgr
+ */
+struct PendingRelDeleteAction
+{
+	/* The flag to tell action support function in current pending delete */
+	int			flags;
+
+	/* Used to destroy pending delete item */
+	void		(*destroy_pending_rel_delete) (PendingRelDelete *reldelete);
+
+	/* do delete function */
+	void		(*do_pending_rel_delete) (PendingRelDelete *reldelete);
+};
+
+/* the flags in pending delete action
+ * do NOT register XLOG/SYNC if current relation is not HEAP/AO/AOCS
+ * after CBDB support custom WAL resouce manager, then different
+ * pending delete item can define different WAL log. But for now,
+ * CBDB only support pg pending item record WAL log.
+ */
+#define PENDING_REL_DELETE_NONE_FLAG (0)
+#define PENDING_REL_DELETE_NEED_PRESERVE (1)
+#define PENDING_REL_DELETE_NEED_XLOG (1 << 1)
+#define PENDING_REL_DELETE_NEED_SYNC (1 << 2)
+
 extern SMgrRelation RelationCreateStorage(RelFileNode rnode,
 										  char relpersistence,
 										  SMgrImpl smgr_which,
@@ -37,6 +99,9 @@ extern bool RelFileNodeSkippingWAL(RelFileNode rnode);
 extern Size EstimatePendingSyncsSpace(void);
 extern void SerializePendingSyncs(Size maxSize, char *startAddress);
 extern void RestorePendingSyncs(char *startAddress);
+
+/* register a pending delete item into pending delete list */
+void		RegisterPendingDelete(struct PendingRelDelete *delete);
 
 /*
  * These functions used to be in storage/smgr/smgr.c, which explains the

--- a/src/include/catalog/storage_directory_table.h
+++ b/src/include/catalog/storage_directory_table.h
@@ -14,12 +14,7 @@
 
 #include "utils/relcache.h"
 
-extern void UFileAddCreatePendingEntry(Relation rel, Oid spcId, char *relativePath);
-extern void UFileAddDeletePendingEntry(Relation rel, Oid spcId, char *relativePath);
-
-extern void UFileDoDeletesActions(bool isCommit);
-extern void UFileAtSubCommitSmgr(void);
-extern void UFileAtSubAbortSmgr(void);
+extern void UFileAddPendingDelete(Relation rel, Oid spcId, char *relativePath, bool atCommit);
 extern void DirectoryTableDropStorage(Relation rel);
 
-#endif //STORAGE_DIRECTORY_TABLE_H
+#endif	/* STORAGE_DIRECTORY_TABLE_H */

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -25,8 +25,9 @@
 
 typedef enum SMgrImplementation
 {
+	SMGR_INVALID = -1,
 	SMGR_MD = 0,
-	SMGR_AO = 1
+	SMGR_AO = 1,
 } SMgrImpl;
 
 struct f_smgr;


### PR DESCRIPTION
<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
<!--Remove this section if no corresponding issue.-->


### Change logs

The pending deletes in CBDB can only mount the `relfilenode`.

Current change expand the pending deletes interface, make self-defined structure can be mount in the pending delete list, also can use the self-defined callback decide how to delete the resource. It's very helper for the `UFile` or other extension which will use the different local/remote resource.
 

### Why are the changes needed?

expand the pending delete

### Does this PR introduce any user-facing change?

nope

### How was this patch tested?

none

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
