### PR TITLE
Expand a new external var tag

### DIFF
--- a/src/include/postgres.h
+++ b/src/include/postgres.h
@@ -131,7 +131,8 @@ typedef enum vartag_external
 	VARTAG_INDIRECT = 1,
 	VARTAG_EXPANDED_RO = 2,
 	VARTAG_EXPANDED_RW = 3,
-	VARTAG_ONDISK = 20
+	VARTAG_ONDISK = 20,
+	VARTAG_CUSTOM = 21 /* external toast custom defined tag */
 } vartag_external;
 
 /* this test relies on the specific tag values above */


### PR DESCRIPTION

### Change logs

External toast in CBDB have the fixed structure, the `vartag_external` used to tell which way to detoast it.

If you want to add an external toast implementation in the extension without changing the kernel, then you need to add a new tag in `vartag_external`.

The current change defines an extension generic tag which named `VARTAG_CUSTOM`, this kind of tag is not used in the kernel, which means that the datum returned from the extension should not be a toast with this kind of tag. This tag is only used within the extension.

### Why are the changes needed?

nope

### Does this PR introduce any user-facing change?

nope

### How was this patch tested?

nope

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
