### PR TITLE
Add hook for exec_simple_query and support self-defined spilling memory threshold in cost module.

### DIFF
--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -430,6 +430,18 @@ COptTasks::SetCostModelParams(ICostModel *cost_model)
 			cost_param->GetLowerBoundVal() * optimizer_sort_factor,
 			cost_param->GetUpperBoundVal() * optimizer_sort_factor);
 	}
+	if (optimizer_spilling_mem_threshold > 0.0) {
+		ICostModelParams::SCostParam *cost_param =
+				cost_model->GetCostModelParams()->PcpLookup(
+					CCostModelParamsGPDB::EcpHJSpillingMemThreshold);
+
+			CDouble spill_mem_threshold(optimizer_spilling_mem_threshold);
+			cost_model->GetCostModelParams()->SetParam(
+				cost_param->Id(), spill_mem_threshold,
+				spill_mem_threshold - 0.0,
+				spill_mem_threshold + 0.0);
+	}
+
 }
 
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -363,6 +363,7 @@ int			optimizer_penalize_broadcast_threshold;
 double		optimizer_cost_threshold;
 double		optimizer_nestloop_factor;
 double		optimizer_sort_factor;
+double		optimizer_spilling_mem_threshold;
 
 /* Optimizer hints */
 int			optimizer_join_arity_for_associativity_commutativity;
@@ -4412,13 +4413,24 @@ struct config_real ConfigureNamesReal_gp[] =
 	},
 
 	{
-		{"optimizer_sort_factor",PGC_USERSET, QUERY_TUNING_OTHER,
+		{"optimizer_sort_factor", PGC_USERSET, QUERY_TUNING_OTHER,
 			gettext_noop("Set the sort cost factor in the optimizer, 1.0 means same as default, > 1.0 means more costly than default, < 1.0 means means less costly than default"),
 			NULL,
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_sort_factor,
 		1.0, 0.0, DBL_MAX,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"optimizer_spilling_mem_threshold", PGC_USERSET, QUERY_TUNING_OTHER,
+			gettext_noop("Set the optimizer factor for threshold of spilling to memory, 0.0 means unbounded"),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_spilling_mem_threshold,
+		0.0, 0.0, DBL_MAX,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/tcop/tcopprot.h
+++ b/src/include/tcop/tcopprot.h
@@ -31,6 +31,10 @@ extern int	max_stack_depth;
 extern int	PostAuthDelay;
 extern int	client_connection_check_interval;
 
+/* Hook for query execution.*/
+typedef void (*exec_simple_query_hook_type) (const char *);
+extern exec_simple_query_hook_type exec_simple_query_hook;
+
 /* GUC-configurable parameters */
 
 typedef enum
@@ -89,5 +93,7 @@ extern const char *get_stats_option_name(const char *arg);
 
 extern void enable_client_wait_timeout_interrupt(void);
 extern void disable_client_wait_timeout_interrupt(void);
+
+extern void exec_simple_query(const char *query_string);
 
 #endif							/* TCOPPROT_H */

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -550,6 +550,7 @@ extern int optimizer_penalize_broadcast_threshold;
 extern double optimizer_cost_threshold;
 extern double optimizer_nestloop_factor;
 extern double optimizer_sort_factor;
+extern double optimizer_spilling_mem_threshold;
 
 /* Optimizer hints */
 extern int optimizer_array_expansion_threshold;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -488,6 +488,7 @@
 		"optimizer_sample_plans",
 		"optimizer_search_strategy_path",
 		"optimizer_segments",
+		"optimizer_spilling_mem_threshold",
 		"optimizer_sort_factor",
 		"optimizer_trace_fallback",
 		"optimizer_use_external_constant_expression_evaluation_for_ints",


### PR DESCRIPTION
### Change logs

1. Add hook for exec_simple_query 
2. Add guc optimizer_spilling_mem_threshold to support self-defined spilling memory threshold in cost module.

### Why are the changes needed?

Support more flexible extension.

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

Tested by CI and tpcds.
