### PR TITLE
CPP keywords should not be used as function/parameter names

### DIFF
--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -630,12 +630,12 @@ RestorePendingSyncs(char *startAddress)
 }
 
 void
-RegisterPendingDelete(struct PendingRelDelete *delete)
+RegisterPendingDelete(struct PendingRelDelete *pending)
 {
-	Assert(delete);
-	Assert(delete->action);
-	delete->next = pendingDeletes;
-	pendingDeletes = delete;
+	Assert(pending);
+	Assert(pending->action);
+	pending->next = pendingDeletes;
+	pendingDeletes = pending;
 }
 
 /*

--- a/src/include/catalog/storage.h
+++ b/src/include/catalog/storage.h
@@ -120,7 +120,7 @@ extern void SerializePendingSyncs(Size maxSize, char *startAddress);
 extern void RestorePendingSyncs(char *startAddress);
 
 /* register a pending delete item into pending delete list */
-void		RegisterPendingDelete(struct PendingRelDelete *delete);
+void		RegisterPendingDelete(struct PendingRelDelete *pending);
 
 /*
  * These functions used to be in storage/smgr/smgr.c, which explains the


### PR DESCRIPTION

### Change logs

CPP keywords should not be used as function/parameter names.

current change remove the `delete` which defined as  parameter.

### Why are the changes needed?

nope

### Does this PR introduce any user-facing change?

nope

### How was this patch tested?

nope

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
