### PR TITLE
Re-used index after ALTER COLUMN TYPE shouldn't change relfilenode

### DIFF
--- a/src/test/regress/expected/alter_table_gp.out
+++ b/src/test/regress/expected/alter_table_gp.out
@@ -279,3 +279,88 @@ SELECT * FROM dropped_col_v;
 ----
 (0 rows)
 
+-- alter indexed column to the same type shouldn't change the index' relfilenode on QD and QEs.
+-- helper utilities to check compare relfilenodes
+drop table if exists relfilenodecheck;
+create table relfilenodecheck(segid int, relname text, relfilenodebefore int, relfilenodeafter int, casename text);
+prepare capturerelfilenodebefore as
+insert into relfilenodecheck select -1 segid, relname, pg_relation_filenode(relname::text) as relfilenode, null::int, $1 as casename from pg_class where relname like $2
+union select gp_segment_id segid, relname, pg_relation_filenode(relname::text) as relfilenode, null::int, $1 as casename  from gp_dist_random('pg_class')
+where relname like $2 order by segid;
+prepare checkrelfilenodediff as
+select a.segid, b.casename, b.relname, (relfilenodebefore != a.relfilenode) rewritten
+from
+    (
+        select -1 segid, relname, pg_relation_filenode(relname::text) as relfilenode
+        from pg_class
+        where relname like $2
+        union
+        select gp_segment_id segid, relname, pg_relation_filenode(relname::text) as relfilenode
+        from gp_dist_random('pg_class')
+        where relname like $2 order by segid
+    )a, relfilenodecheck b
+where b.casename like $1 and b.relname like $2 and a.segid = b.segid;
+create table attype_indexed(a int, b int);
+create index attype_indexed_i on attype_indexed(b);
+insert into attype_indexed select i,i from generate_series(1, 100)i;
+-- alter to same type.
+-- check relfilenode before AT
+execute capturerelfilenodebefore('alter column type same', 'attype_indexed_i');
+alter table attype_indexed alter column b type int;
+-- relfilenode stay same as before
+execute checkrelfilenodediff('alter column type same', 'attype_indexed_i');
+ segid |        casename        |     relname      | rewritten 
+-------+------------------------+------------------+-----------
+     0 | alter column type same | attype_indexed_i | f
+     1 | alter column type same | attype_indexed_i | f
+     2 | alter column type same | attype_indexed_i | f
+    -1 | alter column type same | attype_indexed_i | f
+(4 rows)
+
+-- insert works fine
+insert into attype_indexed select i,i from generate_series(1, 100)i;
+select count(*) from attype_indexed;
+ count 
+-------
+   200
+(1 row)
+
+-- alter to different type, relfilenode should change
+execute capturerelfilenodebefore('alter column diff type', 'attype_indexed_i');
+alter table attype_indexed alter column b type text;
+execute checkrelfilenodediff('alter column diff type', 'attype_indexed_i');
+ segid |        casename        |     relname      | rewritten 
+-------+------------------------+------------------+-----------
+     0 | alter column diff type | attype_indexed_i | t
+     1 | alter column diff type | attype_indexed_i | t
+     2 | alter column diff type | attype_indexed_i | t
+    -1 | alter column diff type | attype_indexed_i | t
+(4 rows)
+
+--insert works fine
+insert into attype_indexed select i, 'abc'::text from generate_series(1, 100) i;
+select count(*) from attype_indexed;
+ count 
+-------
+   300
+(1 row)
+
+-- alter column with exclusion constraint
+create table attype_indexed_constr(
+    c circle,
+    dkey inet,
+    exclude using gist (dkey inet_ops with =, c with &&)
+);
+-- not change
+execute capturerelfilenodebefore('alter column diff type', 'attype_indexed_constr_dkey_c_excl');
+alter table attype_indexed_constr alter column c type circle;
+execute checkrelfilenodediff('alter column diff type', 'attype_indexed_constr_dkey_c_excl');
+ segid |        casename        |              relname              | rewritten 
+-------+------------------------+-----------------------------------+-----------
+     0 | alter column diff type | attype_indexed_constr_dkey_c_excl | f
+     1 | alter column diff type | attype_indexed_constr_dkey_c_excl | f
+     2 | alter column diff type | attype_indexed_constr_dkey_c_excl | f
+    -1 | alter column diff type | attype_indexed_constr_dkey_c_excl | f
+(4 rows)
+
+drop table relfilenodecheck;


### PR DESCRIPTION
During ALTER COLUMN TYPE of an indexed column, we check if the index can be re-used. If so, we preserve the existing relfilenode instead of removing it. However, in GPDB the preservation is done on QD and the relfilenode is packaged in another ALTER TABLE subcommand to be handled later. So QE might make its index to have QD's relfilenode, which could cause data missing/corruption errors.

The fix is for QE to go through the generated index command, and replace QD's relfilenode with its own.

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
