### PR TITLE
Call the query_info_collect_hook directly if expection happens

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -238,7 +238,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 		{
 			PG_TRY();
 			{
-				switch(*gp_resmanager_memory_policy)
+				switch (*gp_resmanager_memory_policy)
 				{
 					case RESMANAGER_MEMORY_POLICY_AUTO:
 						PolicyAutoAssignOperatorMemoryKB(queryDesc->plannedstmt,
@@ -255,7 +255,10 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			}
 			PG_CATCH();
 			{
-				mppExecutorCleanup(queryDesc);
+				/* GPDB hook for collecting query info */
+				if (query_info_collect_hook)
+					(*query_info_collect_hook)(QueryCancelCleanup ? METRICS_QUERY_CANCELED : METRICS_QUERY_ERROR, queryDesc);
+
 				PG_RE_THROW();
 			}
 			PG_END_TRY();


### PR DESCRIPTION
**Cherry-pick from GreenPlum**

GPCC needs that hook, but don't call `mppExecutorCleanup()` since `queryDesc->estate` is NULL in that case.