### PR TITLE
re-enable the external FTS ICW

### DIFF
--- a/hd-ci/compile_cbdb.bash
+++ b/hd-ci/compile_cbdb.bash
@@ -84,7 +84,7 @@ CBDB_VERSION=${CBDB_VERSION}
 EOF
 	else
 		cat <<EOF >>"${SRC_PATH}/cbdb-artifacts.txt"
-external_tar_download_url=${tar_package_path}
+external_tar_download_url="${ROOT_PATH}"/cloudberrydb/gpdb_artifacts/${tar_upload_file_name}
 external_rpm_download_url=${rpm_package_path}
 external_fts_RELEASE_cbdb_${OS_TYPE}_${OS_ARCH}_url=${rpm_download_url}
 external_fts_TARGZ_cbdb_${OS_TYPE}_${OS_ARCH}_url=${tar_download_url}

--- a/src/backend/postmaster/interrupt.c
+++ b/src/backend/postmaster/interrupt.c
@@ -22,6 +22,7 @@
 #include "storage/latch.h"
 #include "storage/procsignal.h"
 #include "utils/guc.h"
+#include "utils/faultinjector.h"
 
 volatile sig_atomic_t ConfigReloadPending = false;
 volatile sig_atomic_t ShutdownRequestPending = false;
@@ -71,6 +72,8 @@ SignalHandlerForConfigReload(SIGNAL_ARGS)
 void
 SignalHandlerForCrashExit(SIGNAL_ARGS)
 {
+	SIMPLE_FAULT_INJECTOR("fault_in_background_writer_quickdie");
+
 	/*
 	 * We DO NOT want to run proc_exit() or atexit() callbacks -- we're here
 	 * because shared memory may be corrupted, so we don't want to try to

--- a/src/test/isolation2/expected/fts_segment_reset.out
+++ b/src/test/isolation2/expected/fts_segment_reset.out
@@ -7,10 +7,15 @@
 -- end_matchsubs
 
 -- Let FTS detect/declare failure sooner
-!\retcode gpconfig -c gp_fts_probe_interval -v 10 --masteronly;
-(exited with code 0)
-!\retcode gpstop -u;
-(exited with code 0)
+-- start_ignore
+alter system set gp_fts_probe_interval to 10;
+ALTER
+select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
+-- end_ignore
 
 -- Let the background writer sleep 27 seconds to delay the resetting.
 -- This number is selected because there's a slight chance that FTS senses
@@ -53,7 +58,8 @@ CREATE
 1<:  <... completed>
 ERROR:  fault triggered, fault name:'start_prepare' fault type:'panic'
 2<:  <... completed>
-CREATE
+DETAIL:  Segments are in reset/recovery mode.
+ERROR:  failed to acquire resources on one or more segments
 
 -- We shouldn't see failover to mirror
 select gp_request_fts_probe_scan();
@@ -79,14 +85,21 @@ select gp_inject_fault('fault_in_background_writer_quickdie', 'reset', dbid) fro
  Success:        
 (1 row)
 
+select pg_sleep(30);
+ pg_sleep 
+----------
+          
+(1 row)
+
+-- start_ignore
+-- restore parameters
+alter system reset gp_fts_probe_interval;
+select pg_reload_conf();
+-- end_ignore
+
 -- The only table that should have been created successfully
 drop table fts_reset_t3;
 DROP
 
 -- In case anything goes wrong, we don't want to affect other tests. So rebalance the cluster anyway.
-!\retcode gprecoverseg -aF !\retcode gprecoverseg -ar 
--- restore parameters
-!\retcode gpconfig -r gp_fts_probe_interval --masteronly;
-(exited with code 127)
-!\retcode gpstop -u;
-(exited with code 0)
+!\retcode gprecoverseg -aF !\retcode gprecoverseg -ar


### PR DESCRIPTION
<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

Current ICW `external_fts pipeline` is not running with the external-fts version.

Current PR change the package and fix the invalid case `fts_segment_reset`.

### Why are the changes needed?



### Does this PR introduce any user-facing change?



### How was this patch tested?



### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
