### PR TITLE
cherry-pick: Work around spurious compiler warning in inet operators

### DIFF
--- a/src/backend/utils/adt/network.c
+++ b/src/backend/utils/adt/network.c
@@ -1889,7 +1889,7 @@ inetnot(PG_FUNCTION_ARGS)
 		unsigned char *pip = ip_addr(ip);
 		unsigned char *pdst = ip_addr(dst);
 
-		while (nb-- > 0)
+		while (--nb >= 0)
 			pdst[nb] = ~pip[nb];
 	}
 	ip_bits(dst) = ip_bits(ip);
@@ -1921,7 +1921,7 @@ inetand(PG_FUNCTION_ARGS)
 		unsigned char *pip2 = ip_addr(ip2);
 		unsigned char *pdst = ip_addr(dst);
 
-		while (nb-- > 0)
+		while (--nb >= 0)
 			pdst[nb] = pip[nb] & pip2[nb];
 	}
 	ip_bits(dst) = Max(ip_bits(ip), ip_bits(ip2));
@@ -1953,7 +1953,7 @@ inetor(PG_FUNCTION_ARGS)
 		unsigned char *pip2 = ip_addr(ip2);
 		unsigned char *pdst = ip_addr(dst);
 
-		while (nb-- > 0)
+		while (--nb >= 0)
 			pdst[nb] = pip[nb] | pip2[nb];
 	}
 	ip_bits(dst) = Max(ip_bits(ip), ip_bits(ip2));
@@ -1978,7 +1978,7 @@ internal_inetpl(inet *ip, int64 addend)
 		unsigned char *pdst = ip_addr(dst);
 		int			carry = 0;
 
-		while (nb-- > 0)
+		while (--nb >= 0)
 		{
 			carry = pip[nb] + (int) (addend & 0xFF) + carry;
 			pdst[nb] = (unsigned char) (carry & 0xFF);
@@ -2062,7 +2062,7 @@ inetmi(PG_FUNCTION_ARGS)
 		unsigned char *pip2 = ip_addr(ip2);
 		int			carry = 1;
 
-		while (nb-- > 0)
+		while (--nb >= 0)
 		{
 			int			lobyte;
 


### PR DESCRIPTION
```
gcc 12+ has complaints like the following:

../../../../../pgsql/src/backend/utils/adt/network.c: In function 'inetnot': ../../../../../pgsql/src/backend/utils/adt/network.c:1893:34: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
 1893 |                         pdst[nb] = ~pip[nb];
      |                         ~~~~~~~~~^~~~~~~~~~
../../../../../pgsql/src/include/utils/inet.h:27:23: note: at offset -1 into destination object 'ipaddr' of size 16
   27 |         unsigned char ipaddr[16];       /* up to 128 bits of address */
      |                       ^~~~~~
../../../../../pgsql/src/include/utils/inet.h:27:23: note: at offset -1 into destination object 'ipaddr' of size 16

This is due to a compiler bug:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104986

It has been a year since the bug has been reported without getting fixed. As the warnings are verbose and use of gcc 12 is becoming more common, it seems worth working around the bug. Particularly because a simple reformulation of the loop condition fixes the issue and isn't any less readable.

Author: Tom Lane <tgl@sss.pgh.pa.us>
Author: Andres Freund <andres@anarazel.de>
Discussion: https://postgr.es/m/144536.1648326206@sss.pgh.pa.us
Backpatch: 11-
```
<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #494 
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
