### PR TITLE
Add LoongArch(loongarch64) support to s_lock.h

### DIFF
--- a/src/include/storage/s_lock.h
+++ b/src/include/storage/s_lock.h
@@ -625,6 +625,24 @@ tas(volatile slock_t *lock)
 
 #endif	 /* __vax__ */
 
+#if defined(__loongarch__)
+#ifdef HAVE_GCC__SYNC_INT32_TAS
+#define HAS_TEST_AND_SET
+
+#define TAS(lock) tas(lock)
+
+typedef int slock_t;
+
+static __inline__ int
+tas(volatile slock_t *lock)
+{
+	return __sync_lock_test_and_set(lock, 1);
+}
+
+#define S_UNLOCK(lock) __sync_lock_release(lock)
+
+#endif	 /* HAVE_GCC__SYNC_INT32_TAS */
+#endif /* __loongarch__ */
 
 #if defined(__mips__) && !defined(__sgi)	/* non-SGI MIPS */
 #define HAS_TEST_AND_SET


### PR DESCRIPTION
<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->

<!--Remove this section if no corresponding issue.-->

---

### Change logs

Add LoongArch64 CPU support, support slock_t for LoongArch64 CPU 

### Why are the changes needed?


### Does this PR introduce any user-facing change?


### How was this patch tested?


### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
