### PR TITLE
Refactor cbdb_log to use vfprintf

### DIFF
--- a/src/fe_utils/log.c
+++ b/src/fe_utils/log.c
@@ -97,28 +97,17 @@ cbdb_log(cbdb_log_level level, const char* file, int line, const char* format, .
     snprintf(timestamp, MAX_TIMESTAMP_LENGTH, "%s.%06ld", date, (long) tv.tv_usec);
 
     // record timestamp, file name, and line num
-    len = snprintf(NULL, 0, fmt, timestamp, s_level[level], file, line);
-    if (len > 0)
-    {
-        char buffer[1000];
-        snprintf(buffer, len + 1, fmt, timestamp, s_level[level], file, line);
-        buffer[len] = 0;
-        fprintf(log_file, "%s,", buffer);
-    }
+    fprintf(log_file, fmt, timestamp, s_level[level], file, line);
+    fprintf(log_file, ",");
 
     // record log information
     va_list arg_ptr;
     va_start(arg_ptr, format);
-    len = vsnprintf(NULL, 0, format, arg_ptr);
+    len = vfprintf(log_file, format, arg_ptr);
     va_end(arg_ptr);
     if (len > 0)
     {
-        char buffer[1000];
-        va_start(arg_ptr, format);
-        vsnprintf(buffer, len + 1, format, arg_ptr);
-        va_end(arg_ptr);
-        buffer[len] = 0;
-        fprintf(log_file, "%s\n", buffer);   
+        fprintf(log_file, "\n");
     }
 
     cur_line_num ++;


### PR DESCRIPTION
* Replaced fprintf with vfprintf in cbdb_log to handle variable arguments more efficiently

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #89 
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
