### PR TITLE
Fix bsearch compare function in guc.c

### DIFF
--- a/src/backend/task/entry.c
+++ b/src/backend/task/entry.c
@@ -286,7 +286,7 @@ get_range(bits, low, high, names, ch, file)
 	register int	i;
 	auto int		num1,
 					num2,
-					num3;
+					num3 = 1;
 
 	Debug(DPARS|DEXT, ("get_range()...entering, exit won't show\n"))
 
@@ -343,9 +343,6 @@ get_range(bits, low, high, names, ch, file)
 		ch = get_number(&num3, 0, PPC_NULL, ch, file);
 		if (ch == EOF || num3 <= 0)
 			return EOF;
-	} else {
-		/* no step.  default==1. */
-		num3 = 1;
 	}
 
 	/*


### PR DESCRIPTION
The prototype of the bsearch()'s compare function is
`int (*compar)(const void *, const void *));`

The first argument is expected to the key object,
the second is the array member.

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
