### PR TITLE
Define EXT_OID_START to suggest oid range for extensions.

### DIFF
--- a/src/include/catalog/gp_matview_aux.h
+++ b/src/include/catalog/gp_matview_aux.h
@@ -23,7 +23,7 @@
 /*
  * Defines for gp_matview_aux
  */
-CATALOG(gp_matview_aux,7061,GpMatviewAuxId) BKI_SHARED_RELATION
+CATALOG(gp_matview_aux,7153,GpMatviewAuxId) BKI_SHARED_RELATION
 {
 	Oid			mvoid; 	/* materialized view oid */
 	NameData	mvname; /* materialized view name */

--- a/src/include/catalog/gp_oid_divide.h
+++ b/src/include/catalog/gp_oid_divide.h
@@ -1,0 +1,30 @@
+/*-------------------------------------------------------------------------
+ *
+ * oid_divide.h
+ * 
+ * Portions Copyright (c) 2024-Present HashData, Inc. or its affiliates.
+ *
+ *
+ * IDENTIFICATION
+ *	    src/include/catalog/oid_divide.h
+ *
+ * NOTES
+ * 		This is used to divide oid range for core and extensions
+ *  	to avoid duplicated.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef GP_OID_DIVIDE_H
+#define GP_OID_DIVIDE_H
+
+/*
+ * Extensions should use Oids start from EXT_OID_START!
+ *
+ * To avoid duplicated oids across extensions or repos.
+ * We strongly suggest extesions should begin from EXT_OID_START
+ * to separate kernel and extensions.
+ */
+#define EXT_OID_START 9932
+
+#endif			/* GP_OID_DIVIDE_H */


### PR DESCRIPTION
Fix GpMatviewAuxId has duplicated oid with other extensions.
 All extension should use oids start from EXT_OID_START to avoid this issue.

Authored-by: Zhang Mingli avamingli@gmail.com

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
