### PR TITLE
Fix copy to directory table always return 1.

### DIFF
--- a/src/backend/commands/copyto.c
+++ b/src/backend/commands/copyto.c
@@ -1878,7 +1878,10 @@ CopyToDispatchDirectoryTable(CopyToState cstate)
 
 	pfree(cdbCopy);
 
-	return 1;
+	if (processed)
+		return 1;
+	else
+		return 0;
 }
 
 /*

--- a/src/test/regress/input/directory_table.source
+++ b/src/test/regress/input/directory_table.source
@@ -388,6 +388,8 @@ COPY BINARY dir_table2 TO '@abs_srcdir@/data/dir_table2';  -- fail
 COPY BINARY dir_table1 TO '@abs_srcdir@/data/dir_table1';   -- fail
 \COPY BINARY DIRECTORY TABLE dir_table1 'nation1' TO '@abs_srcdir@/data/nation1';   -- OK
 COPY BINARY DIRECTORY TABLE dir_table1 'nation1' TO '@abs_srcdir@/data/nation1';   -- OK
+\COPY BINARY DIRECTORY TABLE dir_table1 'unknown' TO '@abs_srcdir@/data/unknown';   -- OK
+COPY BINARY DIRECTORY TABLE dir_table1 'unknown' TO '@abs_srcdir@/data/unknown';    -- OK
 \COPY BINARY DIRECTORY TABLE dir_table1 'nation2' TO stdin; -- OK
 COPY BINARY DIRECTORY TABLE dir_table1 'nation2' TO stdin; -- OK
 \COPY BINARY DIRECTORY TABLE dir_table1 'nation2' TO stdout; -- OK

--- a/src/test/regress/output/directory_table.source
+++ b/src/test/regress/output/directory_table.source
@@ -1044,6 +1044,8 @@ COPY BINARY dir_table1 TO '@abs_srcdir@/data/dir_table1';   -- fail
 ERROR:  COPY to directory table must specify the relative_path name.
 \COPY BINARY DIRECTORY TABLE dir_table1 'nation1' TO '@abs_srcdir@/data/nation1';   -- OK
 COPY BINARY DIRECTORY TABLE dir_table1 'nation1' TO '@abs_srcdir@/data/nation1';   -- OK
+\COPY BINARY DIRECTORY TABLE dir_table1 'unknown' TO '@abs_srcdir@/data/unknown';   -- OK
+COPY BINARY DIRECTORY TABLE dir_table1 'unknown' TO '@abs_srcdir@/data/unknown';    -- OK
 \COPY BINARY DIRECTORY TABLE dir_table1 'nation2' TO stdin; -- OK
 0|ALGERIA|0| haggle. carefully final deposits detect slyly agai
 1|ARGENTINA|1|al foxes promise slyly according to the regular accounts. bold requests alon

--- a/src/test/regress/output/directory_table_optimizer.source
+++ b/src/test/regress/output/directory_table_optimizer.source
@@ -1044,6 +1044,8 @@ COPY BINARY dir_table1 TO '@abs_srcdir@/data/dir_table1';   -- fail
 ERROR:  COPY to directory table must specify the relative_path name.
 \COPY BINARY DIRECTORY TABLE dir_table1 'nation1' TO '@abs_srcdir@/data/nation1';   -- OK
 COPY BINARY DIRECTORY TABLE dir_table1 'nation1' TO '@abs_srcdir@/data/nation1';   -- OK
+\COPY BINARY DIRECTORY TABLE dir_table1 'unknown' TO '@abs_srcdir@/data/unknown';   -- OK
+COPY BINARY DIRECTORY TABLE dir_table1 'unknown' TO '@abs_srcdir@/data/unknown';    -- OK
 \COPY BINARY DIRECTORY TABLE dir_table1 'nation2' TO stdin; -- OK
 0|ALGERIA|0| haggle. carefully final deposits detect slyly agai
 1|ARGENTINA|1|al foxes promise slyly according to the regular accounts. bold requests alon


### PR DESCRIPTION
Fix when there is no file in directory table for copy to, the return number is always 1 which should be zero.

Authored-by: Zhang Wenchao zwcpostgres@gmail.com

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
