### PR TITLE
adjust pg_regress to address invalid encoding issue on uos system

### DIFF
--- a/src/test/regress/pg_regress_main.c
+++ b/src/test/regress/pg_regress_main.c
@@ -130,18 +130,16 @@ psql_start_test(const char *testname,
 	 *     $(cat prehook infile)
 	 *     EOF
 	 */
-	offset += snprintf(psql_cmd + offset, sizeof(psql_cmd) - offset,
-					   "%s \"%s%spsql\" -X -a -q -d \"%s\" %s > \"%s\" 2>&1 <<EOF\n"
-					   "$(cat \"%s\" \"%s\")\n"
-					   "EOF",
-					   use_utility_mode ? "env PGOPTIONS='-c gp_role=utility'" : "",
-					   bindir ? bindir : "",
-					   bindir ? "/" : "",
-					   dblist->str,
-					   "-v HIDE_TABLEAM=on -v HIDE_TOAST_COMPRESSION=on",
-					   outfile,
-					   prehook[0] ? prehook : "/dev/null",
-					   infile);
+        offset += snprintf(psql_cmd + offset, sizeof(psql_cmd) - offset,
+                                           "%s \"%s%spsql\" -X -a -q -d \"%s\" %s > \"%s\" < <(cat \"%s\" \"%s\") 2>&1\n",
+                                           use_utility_mode ? "env PGOPTIONS='-c gp_role=utility'" : "",
+                                           bindir ? bindir : "",
+                                           bindir ? "/" : "",
+                                           dblist->str,
+                                           "-v HIDE_TABLEAM=on -v HIDE_TOAST_COMPRESSION=on",
+                                           outfile,
+                                           prehook[0] ? prehook : "/dev/null",
+                                           infile);
 	if (offset >= sizeof(psql_cmd))
 	{
 		fprintf(stderr, _("command too long\n"));


### PR DESCRIPTION
fix #482  

---
An issue encountered within test framework pg_regress, specifically related to character encoding handling on the UOS1050a/1060e systems. 

pg_regress invokes psql to execute SQL scripts, during dispatch_encoding test case test,  an error "invalid byte sequence for encoding 'UTF8': 0xba" encountered when create a table with Russian. This indicates that the system, potentially UOS, was unable to correctly identify certain character sequences as valid UTF-8 encoding, typically pointing to an operating system level bug.

To circumvent this bug, the invocation method of the testing framework was altered. Originally, the call used redirection and heredoc syntax "<<EOF" to pass the SQL script to psql. 
```
' "/usr/local/cloudberry-db-devel/bin/psql" -X -a -q -d "regression" -v HIDE_TABLEAM=on -v HIDE_TOAST_COMPRESSION=on > "/code/cbdb_src/src/test/regress/results/dispatch_encoding.out" 2>&1 <<EOF
$(cat "prehook.sql" "/code/cbdb_src/src/test/regress/sql/dispatch_encoding.sql")
EOF'
```
The revised approach utilized process substitution <(...) which feeds output of a command to psql. The modified command like this:

```
"/usr/local/cloudberry-db-devel/bin/psql" \
-X -a -q -d "regression" \
-v HIDE_TABLEAM=on -v HIDE_TOAST_COMPRESSION=on \
< <(cat "prehook.sql" "/code/cbdb_src/src/test/regress/sql/dispatch_encoding.sql") \
> "/code/cbdb_src/src/test/regress/results/dispatch_encoding.out"
```

By doing so, the original error ceased to occur, allowing the tests to proceed. This could be because process substitution altered the data flow in a way that bypassed the triggering of the operating system-level bug.

In the output of the DDL, gibberish characters such as "ÐºÐ¾Ð»Ð¾Ð½ÐºÐ°" appear, indicative of incorrect UTF-8 encoding, likely due to mishandling by the system when dealing with these special characters. The revised invocation of the testing framework successfully avoided this issue, enabling the tests to run without being hampered by encoding errors.