### PR TITLE
[AQUMV]Allow to use normal materialized views to answer query.

### DIFF
--- a/src/backend/catalog/gp_matview_aux.c
+++ b/src/backend/catalog/gp_matview_aux.c
@@ -421,6 +421,9 @@ bool
 MatviewUsableForAppendAgg(Oid mvoid)
 {
 	HeapTuple mvauxtup = SearchSysCacheCopy1(MVAUXOID, ObjectIdGetDatum(mvoid));
+	if (!HeapTupleIsValid(mvauxtup))
+		return false;
+
 	Form_gp_matview_aux auxform = (Form_gp_matview_aux) GETSTRUCT(mvauxtup);
 	return ((auxform->datastatus == MV_DATA_STATUS_UP_TO_DATE) || 
 			(auxform->datastatus == MV_DATA_STATUS_EXPIRED_INSERT_ONLY));
@@ -438,6 +441,11 @@ bool
 MatviewIsGeneralyUpToDate(Oid mvoid)
 {
 	HeapTuple mvauxtup = SearchSysCacheCopy1(MVAUXOID, ObjectIdGetDatum(mvoid));
+
+	/* Not a candidate we recorded. */
+	if (!HeapTupleIsValid(mvauxtup))
+		return false;
+
 	Form_gp_matview_aux auxform = (Form_gp_matview_aux) GETSTRUCT(mvauxtup);
 	return ((auxform->datastatus == MV_DATA_STATUS_UP_TO_DATE) || 
 			(auxform->datastatus == MV_DATA_STATUS_UP_REORGANIZED));

--- a/src/backend/optimizer/plan/aqumv.c
+++ b/src/backend/optimizer/plan/aqumv.c
@@ -18,6 +18,7 @@
 #include "access/htup_details.h"
 #include "access/table.h"
 #include "catalog/catalog.h"
+#include "catalog/gp_matview_aux.h"
 #include "catalog/pg_class_d.h"
 #include "catalog/pg_inherits.h"
 #include "catalog/pg_rewrite.h"
@@ -168,12 +169,18 @@ answer_query_using_materialized_views(PlannerInfo *root,
 		matviewRel = table_open(rewrite_tup->ev_class, AccessShareLock);
 		need_close = true;
 
+		if (!RelationIsPopulated(matviewRel))
+			continue;
+
 		/*
 		 * AQUMV
 		 * Currently the data of IVM is always up-to-date if there were.
-		 * Take care of this when IVM defered-fefresh is supported.
+		 * Take care of this when IVM defered-fefresh is supported(in SERVERLESS mode).
+		 * 
+		 * Normal materialized views could also be used if its data is up to date.
 		 */
-		if (!(RelationIsIVM(matviewRel) && RelationIsPopulated(matviewRel)))
+		if (!RelationIsIVM(matviewRel) &&
+			!MatviewIsGeneralyUpToDate(RelationGetRelid(matviewRel)))
 			continue;
 
 		if (matviewRel->rd_rel->relhasrules == false ||

--- a/src/test/regress/expected/aqumv.out
+++ b/src/test/regress/expected/aqumv.out
@@ -988,6 +988,118 @@ select count(c2), count(*) from aqumv_t2 where c1 > 90;
 (1 row)
 
 abort;
+-- Test use normal materialized views
+create table t1(c1 int, c2 int, c3 int) distributed by (c1);
+insert into t1 select i, i+1, i+2 from generate_series(1, 100) i;
+insert into t1 values (91, NULL, 95);
+analyze t1;
+create materialized view normal_mv_t1 as
+  select c3 as mc3, c1 as mc1
+  from t1 where c1 > 90;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'mc1' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+analyze normal_mv_t1;
+set enable_answer_query_using_materialized_views = off;
+explain(costs off, verbose)
+select count(c3) from t1 where c1 > 90;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(c3)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(c3))
+         ->  Partial Aggregate
+               Output: PARTIAL count(c3)
+               ->  Seq Scan on aqumv.t1
+                     Output: c1, c2, c3
+                     Filter: (t1.c1 > 90)
+ Settings: enable_answer_query_using_materialized_views = 'off', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select count(c3) from t1 where c1 > 90;
+ count 
+-------
+    11
+(1 row)
+
+set enable_answer_query_using_materialized_views = on;
+explain(costs off, verbose)
+select count(c3) from t1 where c1 > 90;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(mc3)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(mc3))
+         ->  Partial Aggregate
+               Output: PARTIAL count(mc3)
+               ->  Seq Scan on aqumv.normal_mv_t1
+                     Output: mc3, mc1
+ Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select count(c3) from t1 where c1 > 90;
+ count 
+-------
+    11
+(1 row)
+
+vacuum full t1;
+explain(costs off, verbose)
+select count(c3) from t1 where c1 > 90;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(mc3)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(mc3))
+         ->  Partial Aggregate
+               Output: PARTIAL count(mc3)
+               ->  Seq Scan on aqumv.normal_mv_t1
+                     Output: mc3, mc1
+ Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+explain(costs off, verbose)
+select c3 from t1 where c1 > 90;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: mc3
+   ->  Seq Scan on aqumv.normal_mv_t1
+         Output: mc3
+ Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+-- insert data after refresh
+insert into t1 values (91, NULL, 95);
+explain(costs off, verbose)
+select count(c3) from t1 where c1 > 90;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(c3)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(c3))
+         ->  Partial Aggregate
+               Output: PARTIAL count(c3)
+               ->  Seq Scan on aqumv.t1
+                     Output: c1, c2, c3
+                     Filter: (t1.c1 > 90)
+ Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select mvname, datastatus from gp_matview_aux where mvname = 'normal_mv_t1';
+    mvname    | datastatus 
+--------------+------------
+ normal_mv_t1 | e
+(1 row)
+
 -- Test Agg on IMMV who has less columns than origin table.
 begin;
 create table aqumv_t2(c1 int, c2 int, c3 int) distributed by (c1);
@@ -2471,5 +2583,7 @@ select c2, c3 from aqumv_t7 where c1 > 90 order by c2, c3 fetch first 3 rows wit
 abort;
 reset optimizer;
 reset enable_answer_query_using_materialized_views;
-drop table aqumv_t1 cascade;
+-- start_ignore
+drop schema aqumv cascade;
+-- end_ignore
 reset search_path;


### PR DESCRIPTION
As we have enabled materialized view data status maintenance, normal materialized views could also be used to answer query if their data status is up to date.
There is no difference between IVM and normal materialized views to answer query.

example, compute agg from a normal materialized view:
```sql
create table t1(c1 int, c2 int, c3 int) distributed by (c1);

create materialized view normal_mv_t1 as
  select c3 as mc3, c1 as mc1 from t1 where c1 > 90;

set enable_answer_query_using_materialized_views = on; 
explain(costs off, verbose)
select count(c3) from t1 where c1 > 90;
                    QUERY PLAN
------------------------------------------------------
 Finalize Aggregate
   Output: count(mc3)
   ->  Gather Motion 3:1  (slice1; segments: 3)
         Output: (PARTIAL count(mc3))
         ->  Partial Aggregate
               Output: PARTIAL count(mc3)
               ->  Seq Scan on aqumv.normal_mv_t1
                     Output: mc3, mc1
 Optimizer: Postgres query optimizer
```
BTW, fix some bugs when we didn't find a tuple from gp_matview_aux which could be possible as we enable using normal
 materialized view(ex: created by bootstrap).
```gdb
#0  __pthread_kill_implementation (no_tid=0, signo=11, threadid=140360340483584) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=11, threadid=140360340483584) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=140360340483584, signo=signo@entry=11) at ./nptl/pthread_kill.c:89
#3  0x00007fa8337bf476 in __GI_raise (sig=11) at ../sysdeps/posix/raise.c:26
#4  0x00007fa834924214 in StandardHandlerForSigillSigsegvSigbus_OnMainThread (
    processName=0x7fa83504665b "Master process", postgres_signal_arg=11) at elog.c:5377
#5  0x00007fa83471d162 in CdbProgramErrorHandler (postgres_signal_arg=11) at postgres.c:3818
#6  <signal handler called>
#7  0x00007fa8341ef70a in MatviewIsGeneralyUpToDate (mvoid=12317) at gp_matview_aux.c:441
#8  0x00007fa8345a7770 in answer_query_using_materialized_views (root=0x55dc22867e78, current_rel=0x55dc228687d8,
    qp_callback=0x7fa83458e7fb <standard_qp_callback>, qp_extra=0x7ffdde5c77c0) at aqumv.c:183
#9  0x00007fa83458a680 in grouping_planner (root=0x55dc22867e78, tuple_fraction=0) at planner.c:1890
#10 0x00007fa8345898a5 in subquery_planner (glob=0x55dc22814dc8, parse=0x55dc2284bf38, parent_root=0x0,
    hasRecursion=false, tuple_fraction=0, config=0x55dc22867e00) at planner.c:1344
#11 0x00007fa834587a07 in standard_planner (parse=0x55dc2284bf38,
    query_string=0x55dc2270f9b0 "explain(verbose, costs off) select * from aqumv_t1 where c1 = 2;",
    cursorOptions=2048, boundParams=0x0) at planner.c:562
#12 0x00007fa8345872e8 in planner (parse=0x55dc22710cd8,
    query_string=0x55dc2270f9b0 "explain(verbose, costs off) select * from aqumv_t1 where c1 = 2;",
    cursorOptions=2048, boundParams=0x0) at planner.c:332
#13 0x00007fa834717bce in pg_plan_query (querytree=0x55dc22710cd8,
```



Authored-by: Zhang Mingli avamingli@gmail.com

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
