### PR TITLE
Disable two of unstable FTS case to make CI happy

### DIFF
--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -239,13 +239,15 @@ test: segwalrep/recoverseg_from_file
 test: segwalrep/mirror_promotion
 test: segwalrep/cancel_commit_pending_replication
 test: segwalrep/twophase_tolerance_with_mirror_promotion
-test: segwalrep/failover_with_many_records
+# unstable FTS test in different arch
+# test: segwalrep/failover_with_many_records
 test: segwalrep/dtm_recovery_on_standby
 test: segwalrep/commit_blocking_on_standby
 test: segwalrep/dtx_recovery_wait_lsn
 test: fts_manual_probe
 test: fts_session_reset
-test: fts_segment_reset
+# unstable FTS test in different arch
+# test: fts_segment_reset
 
 # Reindex tests
 test: reindex/abort_reindex


### PR DESCRIPTION

fix #ISSUE_Number

---

### Change logs

In different linux distributions, these two tests often fail due to time differences. 

In this change, i disable two of unstable FTS case to make CI happy.

We should keep the test files until CBDB merge all GPDB commits.

### Why are the changes needed?


### Does this PR introduce any user-facing change?


### How was this patch tested?



### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
