### PR TITLE
Add an option in psql to avoid encoding issues on some platforms

### DIFF
--- a/src/bin/psql/command.c
+++ b/src/bin/psql/command.c
@@ -4051,7 +4051,7 @@ process_file(char *filename, bool use_relative_path)
 	}
 
 	oldfilename = pset.inputfile;
-	pset.inputfile = filename;
+	pset.inputfile = ignore_log_file ? NULL : filename;
 
 	pg_logging_config(pset.inputfile ? 0 : PG_LOG_FLAG_TERSE);
 

--- a/src/bin/psql/help.c
+++ b/src/bin/psql/help.c
@@ -100,6 +100,7 @@ usage(unsigned short int pager)
 	fprintf(output, _("  -e, --echo-queries       echo commands sent to server\n"));
 	fprintf(output, _("  -E, --echo-hidden        display queries that internal commands generate\n"));
 	fprintf(output, _("  -L, --log-file=FILENAME  send session log to file\n"));
+	fprintf(output, _("      --ignore-log-file    do not log psql:filename prefix in log file\n"));
 	fprintf(output, _("  -n, --no-readline        disable enhanced command line editing (readline)\n"));
 	fprintf(output, _("  -o, --output=FILENAME    send query results to file (or |pipe)\n"));
 	fprintf(output, _("  -q, --quiet              run quietly (no messages, only query output)\n"));

--- a/src/bin/psql/settings.h
+++ b/src/bin/psql/settings.h
@@ -152,7 +152,7 @@ typedef struct _psqlSettings
 } PsqlSettings;
 
 extern PsqlSettings pset;
-
+extern bool ignore_log_file;
 
 #ifndef EXIT_SUCCESS
 #define EXIT_SUCCESS 0

--- a/src/bin/psql/startup.c
+++ b/src/bin/psql/startup.c
@@ -85,6 +85,8 @@ static void process_psqlrc(char *argv0);
 static void process_psqlrc_file(char *filename);
 static void showVersion(void);
 static void EstablishVariableSpace(void);
+/* ignore psql:filename in log output */
+bool ignore_log_file = false;
 
 #define NOPAGER		0
 
@@ -498,6 +500,7 @@ parse_psql_options(int argc, char *argv[], struct adhoc_opts *options)
 		{"no-psqlrc", no_argument, NULL, 'X'},
 		{"help", optional_argument, NULL, 1},
 		{"csv", no_argument, NULL, 2},
+		{"ignore-log-file", no_argument, NULL, 256},
 		{NULL, 0, NULL, 0}
 	};
 
@@ -693,6 +696,9 @@ parse_psql_options(int argc, char *argv[], struct adhoc_opts *options)
 				break;
 			case 2:
 				pset.popt.topt.format = PRINT_CSV;
+				break;
+			case 256:
+				ignore_log_file = true;
 				break;
 			default:
 		unknown_option:

--- a/src/test/regress/pg_regress_main.c
+++ b/src/test/regress/pg_regress_main.c
@@ -129,6 +129,17 @@ psql_start_test(const char *testname,
 	 *     psql <<EOF
 	 *     $(cat prehook infile)
 	 *     EOF
+	 *
+	 * CBDB:
+	 * However the above command will have strange behavior on some platforms,
+	 * like UOS1050a, UOS1060e. The input stream is unexpectedly changed
+	 * for psql. It looks like a system-level problem that we have nothing
+	 * to do. We change the above command to
+	 *
+	 *     psql -f prehook -f infile --ignore-log-file
+	 *
+	 * --ignore-log-file will suppress additional logging prefix that has
+	 *  the same effect like no filename is provided.
 	 */
 	offset += snprintf(psql_cmd + offset, sizeof(psql_cmd) - offset,
 					   "%s \"%s%spsql\" -X -a -q -d \"%s\" %s > \"%s\" 2>&1  "

--- a/src/test/regress/pg_regress_main.c
+++ b/src/test/regress/pg_regress_main.c
@@ -131,9 +131,8 @@ psql_start_test(const char *testname,
 	 *     EOF
 	 */
 	offset += snprintf(psql_cmd + offset, sizeof(psql_cmd) - offset,
-					   "%s \"%s%spsql\" -X -a -q -d \"%s\" %s > \"%s\" 2>&1 <<EOF\n"
-					   "$(cat \"%s\" \"%s\")\n"
-					   "EOF",
+					   "%s \"%s%spsql\" -X -a -q -d \"%s\" %s > \"%s\" 2>&1  "
+					   "-f \"%s\" -f \"%s\" --ignore-log-file\n",
 					   use_utility_mode ? "env PGOPTIONS='-c gp_role=utility'" : "",
 					   bindir ? bindir : "",
 					   bindir ? "/" : "",


### PR DESCRIPTION
When running ICW tests, the following command has a strange behavior.
```shell
psql ... <<EOF
$(cat prehook inputfile)
EOF
```
The command has an issue on some platforms that will input unexpected data stream to psql. For example, The following first line will become to the second line:
`"колонка 6" int, "колонка 7" int, "колонка 8" int, "колонка 9" int, "колонка 10" int, "колонка 11" int,`

`"колонка 6" int, "колонка 7" int, "колонка 8" int, "колонка 9" int, "колонЀ�а 10" int, "колонка 11" int,`

It's unknown why the input stream is changed. The other similar commands will have correct data stream to psql,
like
```
cat prehook inputfile | psql ...
```
or for a single input file
```
psql ... < inputfile
```

In this commit, we convert the original command to
```shell
psql ... -f prehook -f inputfile --ignore-log-file
```

The new option `--ignore-log-file` will ignore the logging prefix for psql and filename, so the program psql will log like no input filename is provided.

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #482 
<!--Remove this section if no corresponding issue.-->

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
