### PR TITLE
adjust test cases for the cloudberrydb binary swap test

### DIFF
--- a/src/test/binary_swap/expected/resgroup_current_1_queue.out
+++ b/src/test/binary_swap/expected/resgroup_current_1_queue.out
@@ -11,7 +11,8 @@ select rsgname, parent from pg_resgroup
 ---------------+--------
  default_group |      0
  admin_group   |      0
-(2 rows)
+ system_group  |      0
+(3 rows)
 
 select avg(reslimittype)
   from pg_resgroupcapability
@@ -28,7 +29,8 @@ select groupname from gp_toolkit.gp_resgroup_config
 ---------------
  default_group
  admin_group
-(2 rows)
+ system_group
+(3 rows)
 
 select rsgname from gp_toolkit.gp_resgroup_status
   where rsgname not like 'rg_dump_test%'

--- a/src/test/binary_swap/expected/resgroup_current_3_queue.out
+++ b/src/test/binary_swap/expected/resgroup_current_3_queue.out
@@ -11,9 +11,10 @@ select rsgname, parent from pg_resgroup
 ---------------+--------
  default_group |      0
  admin_group   |      0
- rg1           |      0
+ system_group  |      0
  rg2           |      0
-(4 rows)
+ rg1           |      0
+(5 rows)
 
 select avg(reslimittype)
   from pg_resgroupcapability
@@ -30,9 +31,10 @@ select groupname from gp_toolkit.gp_resgroup_config
 ---------------
  default_group
  admin_group
- rg1
+ system_group
  rg2
-(4 rows)
+ rg1
+(5 rows)
 
 select rsgname from gp_toolkit.gp_resgroup_status
   where rsgname not like 'rg_dump_test%'

--- a/src/test/binary_swap/expected/resgroup_other_2_queue.out
+++ b/src/test/binary_swap/expected/resgroup_other_2_queue.out
@@ -11,9 +11,10 @@ select rsgname, parent from pg_resgroup
 ---------------+--------
  default_group |      0
  admin_group   |      0
+ system_group  |      0
  rg1           |      0
  rg2           |      0
-(4 rows)
+(5 rows)
 
 select avg(reslimittype)
   from pg_resgroupcapability
@@ -30,9 +31,10 @@ select groupname from gp_toolkit.gp_resgroup_config
 ---------------
  default_group
  admin_group
+ system_group
  rg1
  rg2
-(4 rows)
+(5 rows)
 
 select rsgname from gp_toolkit.gp_resgroup_status
   where rsgname not like 'rg_dump_test%'

--- a/src/test/binary_swap/schedule1
+++ b/src/test/binary_swap/schedule1
@@ -1,5 +1,5 @@
+test: inserts views
 test: pg_dumpall_current
 test: gpcheckcat
-
 test: resgroup_cleanup_basic
 test: resgroup_current_1_queue

--- a/src/test/binary_swap/schedule3
+++ b/src/test/binary_swap/schedule3
@@ -1,7 +1,5 @@
 test: pg_dumpall_current
 test: diff_dumps
-test: inserts
-test: pg_dumpall_current
 test: gpcheckcat
 
 test: resgroup_current_3_queue

--- a/src/test/binary_swap/sql/inserts.sql
+++ b/src/test/binary_swap/sql/inserts.sql
@@ -2,6 +2,12 @@
 
 -- Insert into tables generated from src/test/regress
 -- Following tables from freeze_aux_tables:
+
+-- start_ignore
+create table if not exists test_table_heap_with_toast (id int, col1 int, col2 text) with (appendonly=false);
+create table if not exists test_table_ao_with_toast (id int, col1 int, col2 text) with (appendonly=true, orientation=row);
+create table if not exists test_table_co_with_toast (id int, col1 int, col2 text) with (appendonly=true, orientation=column);
+-- end_ignore
 INSERT INTO test_table_heap_with_toast SELECT i, i*2, i*5 FROM generate_series(1, 20)i;
 INSERT INTO test_table_ao_with_toast SELECT * FROM test_table_heap_with_toast;
 INSERT INTO test_table_co_with_toast SELECT * FROM test_table_heap_with_toast;


### PR DESCRIPTION
**Change Summary:**

**Change 1: introduction of the "system_group" in Binary Swap test**
Previously, cloudberrydb introduced a new control group named "system_group" to manage the resource usage of the postmaster process and all other auxiliary processes. 

```
select rsgname, parent from pg_resgroup
  where rsgname not like 'rg_dump_test%'
  order by oid;
    rsgname    | parent 
---------------+--------
 default_group |      0
 admin_group   |      0
 system_group  |      0
(3 rows)
```

The "system_group" were added to the following three resource group test cases:
resgroup_current_1_queue
resgroup_other_2_queue
resgroup_current_3_queue

**Change 2: addressing missing DDL for "insert" test case under Binary Swap test suite**

```
create table if not exists test_table_heap_with_toast (id int, col1 int, col2 text) with (appendonly=false);
create table if not exists test_table_ao_with_toast (id int, col1 int, col2 text) with (appendonly=true, orientation=row);
create table if not exists test_table_co_with_toast (id int, col1 int, col2 text) with (appendonly=true, orientation=column);
```

**Change 3: refinement of Binary Swap test suite scheduling** 

The "insert" and second occurrence of "pg_dumpall_current" were deemed unnecessary in the "schedule3" because no subsequent pg_dump comparison. Thus the redundant "pg_dumpall_current" has been removed and test case "insert" has been moved to "schedule1"
