### PR TITLE
Update aocsam.c: fix safeFSWriteSize arg type

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1561,7 +1561,7 @@ aocs_fetch_init(Relation relation,
 				create_datumstreamread(ct,
 									   clvl,
 									   checksum,
-									    /* safeFSWriteSize */ false,	/* UNDONE:Need to wire
+									    /* safeFSWriteSize */ 0,	/* UNDONE:Need to wire
 																		 * down pg_appendonly
 																		 * column */
 									   blksz,

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -263,7 +263,7 @@ open_ds_read(Relation rel, DatumStreamRead **ds, TupleDesc relationTupleDesc,
 		ds[attno] = create_datumstreamread(ct,
 										   clvl,
 										   checksum,
-										    /* safeFSWriteSize */ false,	/* UNDONE:Need to wire
+										    /* safeFSWriteSize */ 0,	/* UNDONE:Need to wire
 																			 * down pg_appendonly
 																			 * column */
 										   blksz,


### PR DESCRIPTION
The goal is to achieve consistent coding with https://github.com/cloudberrydb/cloudberrydb/blob/main/src/backend/access/aocs/aocsam.c#L174

Problem tracks down to commit 6b0e52beadd678c5050af9c978c26d171ba86ae0

No behavior change is expected, just a nit-pick

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [x] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [x] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [x] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [x] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [x] Document changes.
- [x] Add tests for the change
- [x] Pass `make installcheck`
- [x] Pass `make -C src/test installcheck-cbdb-parallel`
- [x] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
