### PR TITLE
Implement READ_STRING_FIELD_NULL serializable read function.

### DIFF
--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -119,8 +119,25 @@
 		} \
 		var = nn;  }
 
+#define READ_STRING_VAR_NULL(var) \
+	{ int slen; char * nn = NULL; \
+		memcpy(&slen, read_str_ptr, sizeof(int)); \
+		read_str_ptr+=sizeof(int); \
+		if (slen>0) { \
+		    nn = palloc(slen+1); \
+		    memcpy(nn,read_str_ptr,slen); \
+		    read_str_ptr+=(slen); nn[slen]='\0'; \
+		} \
+		if (slen==0) { \
+			nn = palloc(1); \
+			nn[0] = '\0'; \
+		} \
+		var = nn;  }
+
 /* Read a character-string field */
 #define READ_STRING_FIELD(fldname)  READ_STRING_VAR(local_node->fldname)
+
+#define READ_STRING_FIELD_NULL(fldname)  READ_STRING_VAR_NULL(local_node->fldname)
 
 /* Read a parse location field (and throw away the value, per notes above) */
 #define READ_LOCATION_FIELD(fldname) READ_INT_FIELD(fldname)
@@ -892,7 +909,7 @@ _readOidAssignment(void)
 	READ_LOCALS(OidAssignment);
 
 	READ_OID_FIELD(catalog);
-	READ_STRING_FIELD(objname);
+	READ_STRING_FIELD_NULL(objname);
 	READ_OID_FIELD(namespaceOid);
 	READ_OID_FIELD(keyOid1);
 	READ_OID_FIELD(keyOid2);

--- a/src/test/regress/expected/gp_types.out
+++ b/src/test/regress/expected/gp_types.out
@@ -41,6 +41,7 @@ SELECT * FROM dml_bitvarying ORDER BY 1;
  00
 (1 row)
 
+CREATE TYPE size_t AS enum('');
 --
 -- Interval
 --
@@ -425,6 +426,7 @@ SELECT float8in(float8out(a)) FROM FLOATS ORDER BY a;
 COPY FLOATS TO '/tmp/floats';
 TRUNCATE FLOATS;
 COPY FLOATS FROM '/tmp/floats';
+DROP TYPE size_t;
 SELECT * FROM FLOATS ORDER BY a;
    a    
 --------

--- a/src/test/regress/sql/gp_types.sql
+++ b/src/test/regress/sql/gp_types.sql
@@ -23,6 +23,8 @@ SELECT * FROM dml_bitvarying ORDER BY 1;
 UPDATE dml_bitvarying SET a = '000';
 SELECT * FROM dml_bitvarying ORDER BY 1;
 
+CREATE TYPE size_t AS enum('');
+
 --
 -- Interval
 --
@@ -171,5 +173,7 @@ SELECT float8in(float8out(a)) FROM FLOATS ORDER BY a;
 COPY FLOATS TO '/tmp/floats';
 TRUNCATE FLOATS;
 COPY FLOATS FROM '/tmp/floats';
+
+DROP TYPE size_t;
 
 SELECT * FROM FLOATS ORDER BY a;


### PR DESCRIPTION
When there is "" string, we need also to palloc memory in OidAssignment.

Authored-by: Zhang Wenchao zwcpostgres@gmail.com

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
