### PR TITLE
Support distributed by clause specification when Create MV if not exists

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -7114,7 +7114,7 @@ CreateMatViewStmt:
 					ctas->into->distributedBy = $10;
 					$$ = (Node *) ctas;
 				}
-		| CREATE OptNoLog incremental MATERIALIZED VIEW IF_P NOT EXISTS create_mv_target AS SelectStmt opt_with_data
+		| CREATE OptNoLog incremental MATERIALIZED VIEW IF_P NOT EXISTS create_mv_target AS SelectStmt opt_with_data OptDistributedBy
 				{
 					CreateTableAsStmt *ctas = makeNode(CreateTableAsStmt);
 					ctas->query = $11;
@@ -7126,6 +7126,7 @@ CreateMatViewStmt:
 					$9->rel->relpersistence = $2;
 					$9->skipData = !($12);
 					$9->ivm = $3;
+					ctas->into->distributedBy = $13;
 					$$ = (Node *) ctas;
 				}
 		;

--- a/src/test/regress/expected/matview.out
+++ b/src/test/regress/expected/matview.out
@@ -522,6 +522,10 @@ DETAIL:  drop cascades to materialized view mvtest_mv_v
 drop cascades to materialized view mvtest_mv_v_2
 drop cascades to materialized view mvtest_mv_v_3
 drop cascades to materialized view mvtest_mv_v_4
+-- Check that CREATE IF NOT EXISTS accept DISTRIBUTED BY
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_ine_distr (a, b) AS
+  SELECT generate_series(1, 10) a, generate_series(1, 10) b  DISTRIBUTED BY (b);
+DROP MATERIALIZED VIEW mv_ine_distr;
 -- Check that unknown literals are converted to "text" in CREATE MATVIEW,
 -- so that we don't end up with unknown-type columns.
 CREATE MATERIALIZED VIEW mv_unspecified_types AS

--- a/src/test/regress/expected/matview.out
+++ b/src/test/regress/expected/matview.out
@@ -525,6 +525,17 @@ drop cascades to materialized view mvtest_mv_v_4
 -- Check that CREATE IF NOT EXISTS accept DISTRIBUTED BY
 CREATE MATERIALIZED VIEW IF NOT EXISTS mv_ine_distr (a, b) AS
   SELECT generate_series(1, 10) a, generate_series(1, 10) b  DISTRIBUTED BY (b);
+\d+ mv_ine_distr
+                         Materialized view "public.mv_ine_distr"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+---------+--------------+-------------
+ a      | integer |           |          |         | plain   |              | 
+ b      | integer |           |          |         | plain   |              | 
+View definition:
+ SELECT generate_series(1, 10) AS a,
+    generate_series(1, 10) AS b;
+Distributed by: (b)
+
 DROP MATERIALIZED VIEW mv_ine_distr;
 -- Check that unknown literals are converted to "text" in CREATE MATVIEW,
 -- so that we don't end up with unknown-type columns.

--- a/src/test/regress/expected/matview_optimizer.out
+++ b/src/test/regress/expected/matview_optimizer.out
@@ -534,6 +534,17 @@ drop cascades to materialized view mvtest_mv_v_4
 -- Check that CREATE IF NOT EXISTS accept DISTRIBUTED BY
 CREATE MATERIALIZED VIEW IF NOT EXISTS mv_ine_distr (a, b) AS
   SELECT generate_series(1, 10) a, generate_series(1, 10) b  DISTRIBUTED BY (b);
+\d+ mv_ine_distr
+                         Materialized view "public.mv_ine_distr"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+---------+--------------+-------------
+ a      | integer |           |          |         | plain   |              | 
+ b      | integer |           |          |         | plain   |              | 
+View definition:
+ SELECT generate_series(1, 10) AS a,
+    generate_series(1, 10) AS b;
+Distributed by: (b)
+
 DROP MATERIALIZED VIEW mv_ine_distr;
 -- Check that unknown literals are converted to "text" in CREATE MATVIEW,
 -- so that we don't end up with unknown-type columns.

--- a/src/test/regress/expected/matview_optimizer.out
+++ b/src/test/regress/expected/matview_optimizer.out
@@ -531,6 +531,10 @@ DETAIL:  drop cascades to materialized view mvtest_mv_v
 drop cascades to materialized view mvtest_mv_v_2
 drop cascades to materialized view mvtest_mv_v_3
 drop cascades to materialized view mvtest_mv_v_4
+-- Check that CREATE IF NOT EXISTS accept DISTRIBUTED BY
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_ine_distr (a, b) AS
+  SELECT generate_series(1, 10) a, generate_series(1, 10) b  DISTRIBUTED BY (b);
+DROP MATERIALIZED VIEW mv_ine_distr;
 -- Check that unknown literals are converted to "text" in CREATE MATVIEW,
 -- so that we don't end up with unknown-type columns.
 CREATE MATERIALIZED VIEW mv_unspecified_types AS

--- a/src/test/regress/sql/matview.sql
+++ b/src/test/regress/sql/matview.sql
@@ -187,6 +187,11 @@ SELECT * FROM mvtest_mv_v_3;
 SELECT * FROM mvtest_mv_v_4;
 DROP TABLE mvtest_v CASCADE;
 
+-- Check that CREATE IF NOT EXISTS accept DISTRIBUTED BY
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_ine_distr (a, b) AS
+  SELECT generate_series(1, 10) a, generate_series(1, 10) b  DISTRIBUTED BY (b);
+DROP MATERIALIZED VIEW mv_ine_distr;
+
 -- Check that unknown literals are converted to "text" in CREATE MATVIEW,
 -- so that we don't end up with unknown-type columns.
 CREATE MATERIALIZED VIEW mv_unspecified_types AS

--- a/src/test/regress/sql/matview.sql
+++ b/src/test/regress/sql/matview.sql
@@ -190,6 +190,7 @@ DROP TABLE mvtest_v CASCADE;
 -- Check that CREATE IF NOT EXISTS accept DISTRIBUTED BY
 CREATE MATERIALIZED VIEW IF NOT EXISTS mv_ine_distr (a, b) AS
   SELECT generate_series(1, 10) a, generate_series(1, 10) b  DISTRIBUTED BY (b);
+\d+ mv_ine_distr
 DROP MATERIALIZED VIEW mv_ine_distr;
 
 -- Check that unknown literals are converted to "text" in CREATE MATVIEW,


### PR DESCRIPTION
$subj

For some reason, current grammatical parser does not accept Distributed By clause in case IF NOT EXISTS specified for materialized view, which I don't any any reason to disallow