### PR TITLE
Suppress compile-time error in SparseData.h

### DIFF
--- a/gpcontrib/gp_sparse_vector/SparseData.h
+++ b/gpcontrib/gp_sparse_vector/SparseData.h
@@ -284,6 +284,8 @@ static inline int64 compword_to_int8(const char *entry)
 			numptr8[6] = entry[7];
 			numptr8[7] = entry[8];
 			break;
+		default:
+			abort();
 	}
 
 	return num;


### PR DESCRIPTION
I compile cloudberry on jammy and it errors like this
```

reshke@ygp-jammy:~/cloudberrydb/gpcontrib/gp_sparse_vector$ gcc -Wall -Wmissing-prototypes -Wpointer-arith -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-unused-but-set-variable -Werror=implicit-fallthrough=3 -Wno-format-truncation -Wno-stringop-truncation -g -g -O2  -flto=auto -ffat-lto-objects -flto=auto -ffat-lto-objects -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer -fno-lto -Wall -fPIC  -DUSE_INTERNAL_FTS=1  -Werror=uninitialized -Werror -std=gnu99 -fsigned-char -fPIC -I. -I. -I../../src/include   -Wdate-time -D_FORTIFY_SOURCE=2 -fno-omit-frame-pointer -fno-lto -fno-fat-lto-objects -Wall -D_GNU_SOURCE -I/usr/include/libxml2   -c -o SparseData.o SparseData.c
In file included from SparseData.c:21:
In function ‘compword_to_int8’,
    inlined from ‘sdata_to_float8arr’ at SparseData.c:248:14:
SparseData.h:291:16: error: ‘num’ may be used uninitialized [-Werror=maybe-uninitialized]
  291 |         return num;
      |                ^~~
SparseData.c: In function ‘sdata_to_float8arr’:
SparseData.h:255:15: note: ‘num’ declared here
  255 |         int64 num;
      |               ^~~
In function ‘compword_to_int8’,
    inlined from ‘sdata_index_to_int64arr’ at SparseData.c:274:17:
SparseData.h:291:16: error: ‘num’ may be used uninitialized [-Werror=maybe-uninitialized]
  291 |         return num;
      |                ^~~
SparseData.c: In function ‘sdata_index_to_int64arr’:
SparseData.h:255:15: note: ‘num’ declared here
  255 |         int64 num;
      |               ^~~
cc1: all warnings being treated as errors
```


Provided patch suppresses this. 
