### PR TITLE
Fix bug with base relation truncate for IMMV

### DIFF
--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -3291,12 +3291,13 @@ clean_up_IVM_hash_entry(MV_TriggerHashEntry *entry, bool is_abort)
 	{
 		MV_TriggerTable *table = (MV_TriggerTable *) lfirst(lc);
 
-		if (table->old_tuplestores) {
+		if (table->old_tuplestores)
+		{
 			list_free(table->old_tuplestores);
 			table->old_tuplestores = NIL;
 		}
-
-		if (table->new_tuplestores) {
+		if (table->new_tuplestores)
+		{
 			list_free(table->new_tuplestores);
 			table->new_tuplestores = NIL;
 		}
@@ -3309,7 +3310,8 @@ clean_up_IVM_hash_entry(MV_TriggerHashEntry *entry, bool is_abort)
 		}
 	}
 
-	if (entry->tables) {
+	if (entry->tables)
+	{
 		list_free(entry->tables);
 		entry->tables = NIL;
 	}

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -1723,8 +1723,7 @@ ivm_immediate_maintenance(PG_FUNCTION_ARGS)
 		if (!(query->hasAggs && query->groupClause == NIL))
 			ExecuteTruncateGuts(list_make1(matviewRel), list_make1_oid(matviewOid),
 							NIL, DROP_RESTRICT, false, NULL);
-		else
-		 if (Gp_role == GP_ROLE_DISPATCH)
+		else if (Gp_role == GP_ROLE_DISPATCH)
 			ExecuteTruncateGuts_IVM(matviewRel, matviewOid, query);
 
 		/* Clean up hash entry and delete tuplestores */

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -3303,9 +3303,18 @@ clean_up_IVM_hash_entry(MV_TriggerHashEntry *entry, bool is_abort)
 		}
 		if (!is_abort)
 		{
-			if (CurrentResourceOwner == entry->resowner) {
-				ExecDropSingleTupleTableSlot(table->slot);
-				table_close(table->rel, NoLock);
+			if (CurrentResourceOwner == entry->resowner)
+			{
+				if (table->slot) 
+				{
+					ExecDropSingleTupleTableSlot(table->slot);
+					table->slot = NULL;
+				}
+				if (table->rel)
+				{
+					table_close(table->rel, NoLock);
+					table->rel = NULL;
+				}
 			}
 		}
 	}

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -336,6 +336,16 @@ SELECT SUM(j), COUNT(j), AVG(j) FROM mv_base_a;
 (1 row)
 
 ROLLBACK;
+-- TRUNCATE a base table without transaction block.
+CREATE TABLE mv_base_simple(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_simple AS SELECT * FROM mv_base_simple;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+TRUNCATE mv_base_simple;
+DROP TABLE mv_base_simple CASCADE;
+NOTICE:  drop cascades to materialized view mv_ivm_simple
 -- resolved issue: When use AVG() function and values is indivisible, result of AVG() is incorrect.
 BEGIN;
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_avg_bug AS SELECT i, SUM(j), COUNT(j), AVG(j) FROM mv_base_A GROUP BY i;

--- a/src/test/regress/sql/incremental_matview.sql
+++ b/src/test/regress/sql/incremental_matview.sql
@@ -141,6 +141,12 @@ SELECT sum, count, avg FROM mv_ivm_group;
 SELECT SUM(j), COUNT(j), AVG(j) FROM mv_base_a;
 ROLLBACK;
 
+-- TRUNCATE a base table without transaction block.
+CREATE TABLE mv_base_simple(i int);
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_simple AS SELECT * FROM mv_base_simple;
+TRUNCATE mv_base_simple;
+DROP TABLE mv_base_simple CASCADE;
+
 -- resolved issue: When use AVG() function and values is indivisible, result of AVG() is incorrect.
 BEGIN;
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_avg_bug AS SELECT i, SUM(j), COUNT(j), AVG(j) FROM mv_base_A GROUP BY i;


### PR DESCRIPTION
On current HEAD, there is bug with base table TRUNCATE for IMMV
```
reshke=# create table tt(i int);
NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Cloudberry Database data distribution key for this table.
HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
CREATE TABLE
reshke=# create incremental materialized view mv1 as select * from tt ;
NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i' as the Cloudberry Database data distribution key for this table.
HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
SELECT 0
reshke=# truncate tt;
WARNING:  relcache reference leak: relation "tt" not closed  (seg0 127.0.1.1:7002 pid=17791)
WARNING:  TupleDesc reference leak: TupleDesc 0x7fcdea6d9570 (40987,-1) still referenced  (seg0 127.0.1.1:7002 pid=17791)
WARNING:  relcache reference leak: relation "tt" not closed  (seg1 127.0.1.1:7003 pid=17792)
WARNING:  TupleDesc reference leak: TupleDesc 0x7f8af3e2c570 (40987,-1) still referenced  (seg1 127.0.1.1:7003 pid=17792)
WARNING:  relcache reference leak: relation "tt" not closed  (seg2 127.0.1.1:7004 pid=17793)
WARNING:  TupleDesc reference leak: TupleDesc 0x7f4424548570 (40987,-1) still referenced  (seg2 127.0.1.1:7004 pid=17793)
WARNING:  relcache reference leak: relation "tt" not closed
WARNING:  TupleDesc reference leak: TupleDesc 0x7f8855f23558 (40987,-1) still referenced
TRUNCATE TABLE
```

Provided patch fixes it. 

Fix borrowed from https://www.postgresql.org/message-id/20240711132357.fe3f78c184cfa99159208178%40sranhm.sraoss.co.jp
