### PR TITLE
Enable fsync=on by default in gpAux/gpdemo/gpdemo-defaults.sh

### DIFF
--- a/gpAux/gpdemo/gpdemo-defaults.sh
+++ b/gpAux/gpdemo/gpdemo-defaults.sh
@@ -16,7 +16,7 @@ if [ "${NUM_PRIMARY_MIRROR_PAIRS}" -eq "0" ]; then
   BLDWRAP_POSTGRES_CONF_ADDONS="fsync=on ${BLDWRAP_POSTGRES_CONF_ADDONS}"  # always enable fsync if singlenode
 fi
 if [[ ! ${BLDWRAP_POSTGRES_CONF_ADDONS} == *"fsync=on"* ]]; then
-  BLDWRAP_POSTGRES_CONF_ADDONS="fsync=off ${BLDWRAP_POSTGRES_CONF_ADDONS}" # only append fsync=off if it doesn't contains fsync=on
+  BLDWRAP_POSTGRES_CONF_ADDONS="fsync=on ${BLDWRAP_POSTGRES_CONF_ADDONS}" # always fsync=on
 else
   BLDWRAP_POSTGRES_CONF_ADDONS="${BLDWRAP_POSTGRES_CONF_ADDONS}"
 fi


### PR DESCRIPTION
Previously, fsync was set to off by default unless NUM_PRIMARY_MIRROR_PAIRS was zero or fsync was explicitly set to on. This change ensures that fsync is always on, improving data durability and consistency by default in the demo setup.

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #544 
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
