### PR TITLE
issue583 fix (copyfrom_internal.h is not included by chance).

### DIFF
--- a/gpcontrib/pxf_fdw/pxf_fragment.c
+++ b/gpcontrib/pxf_fdw/pxf_fragment.c
@@ -5,7 +5,7 @@
 #include "cdb/cdbtm.h"
 #include "cdb/cdbvars.h"
 #include "commands/copy.h"
-#if (PG_VERSION_NUM <= 140000)
+#if (PG_VERSION_NUM >= 140000)
 #include "commands/copyfrom_internal.h"
 #endif
 #include "common/jsonapi.h"


### PR DESCRIPTION
https://github.com/cloudberrydb/cloudberrydb/issues/583

== repro step ==

as issue described

== compile failure ==

pxf_fragment.c: In function ‘ProcessRequest’:
pxf_fragment.c:547:15: error: ‘RAW_BUF_SIZE’ undeclared (first use in this function)
  547 |  char  buffer[RAW_BUF_SIZE];
      |               ^~~~~~~~~~~~

== analysis ==

RAW_BUF_SIZE is defined in copyfrom_internal.h

src/include/commands/copyfrom_internal.h:#define RAW_BUF_SIZE 65536		/* we palloc RAW_BUF_SIZE+1 bytes */

in pxf_fragment.c

#if (PG_VERSION_NUM <= 140000) 
#include "commands/copyfrom_internal.h"
#endif

PG version is 14.4,

PG_VERSION_NUM is 140004

happen to see below code in pxf_fdw.c

#if (PG_VERSION_NUM >= 140000)
#include "commands/copyfrom_internal.h"
#include "commands/copyto_internal.h"
#endif

the one in pxf_fragment.c looks to be typo 

#if (PG_VERSION_NUM <= 140000)            ==> should be (PG_VERSION_NUM >= 140000)
#include "commands/copyfrom_internal.h"
#endif

note: git log history for the two files

- git log pxf_fdw.c

commit 10538adb70ac5e81abbe0cb16a9e1cf66ad808ec
Merge: d5573b984b d457cb4e8a
Author: Cloudberry <cloudberry@initial.code.dump>
Date:   Wed Jun 7 08:57:14 2023 +0000

    Initial Cloudberry code dump.

commit 7c3ae7bb6af5c9f25f31b153eb9e9e4ee3f89fd1
Author: Ashwin Agrawal <aashwin@vmware.com>
Date:   Tue Jan 12 09:38:40 2021 -0800

    Change "ON MASTER" to "ON COORDINATOR" for gpcontrib

    Reviewed-by: Jesse Zhang <sbjesse@gmail.com>

commit 19cd1cf4b68faff2e29bc2fa884c480e4644cdb4
Merge: a714299cd7 9e1c9f9594
Author: Heikki Linnakangas <hlinnakangas@pivotal.io>
Date:   Tue Sep 22 18:12:30 2020 +0300

    Merge with PostgreSQL version 12 (up to a point between beta2 and beta3).

...

- git log pxf_fragment.c

commit 10538adb70ac5e81abbe0cb16a9e1cf66ad808ec
Merge: d5573b984b d457cb4e8a
Author: Cloudberry <cloudberry@initial.code.dump>
Date:   Wed Jun 7 08:57:14 2023 +0000

    Initial Cloudberry code dump.

commit 3b1ada53a0e3b1702e9a64debf1cd7cbb2a9c360
Author: Oliver Albertini <oalbertini@pivotal.io>
Date:   Thu Jan 30 15:16:58 2020 -0800

    Remove gpcontrib/pxf, rename {,gp}contrib/pxf_fdw

    Now that we are moving to FDW, we can remove the old external
    table-based PXF module. Since PXF FDW only currently supports Greenplum
    (not stand-alone Postgres) `pxf_fdw` should live under `gpcontrib`.

    Authored-by: Oliver Albertini <oalbertini@pivotal.io>
(END)
