### PR TITLE
Fix serialization of expr AEXPR_NOT_DISTINCT.

### DIFF
--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -493,6 +493,10 @@ _outAExpr(StringInfo str, A_Expr *node)
 
 			WRITE_NODE_FIELD(name);
 			break;
+		case AEXPR_NOT_DISTINCT:
+
+			WRITE_NODE_FIELD(name);
+			break;
 		case AEXPR_NULLIF:
 
 			WRITE_NODE_FIELD(name);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -558,6 +558,9 @@ _readAExpr(void)
 
 			READ_NODE_FIELD(name);
 			break;
+		case AEXPR_NOT_DISTINCT:
+			READ_NODE_FIELD(name);
+			break;
 		case AEXPR_NULLIF:
 
 			READ_NODE_FIELD(name);

--- a/src/test/regress/expected/create_table.out
+++ b/src/test/regress/expected/create_table.out
@@ -1282,6 +1282,10 @@ CREATE UNLOGGED TABLE unlogged_toast (a text);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Cloudberry Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 TRUNCATE unlogged_toast;
+-- test https://github.com/cloudberrydb/cloudberrydb/issues/595
+CREATE TABLE t_issue_595(c0 DECIMAL UNIQUE DEFAULT (0.059636344153715326) PRIMARY KEY,
+	c1 money CHECK (((t_issue_595.c1)IS NOT DISTINCT FROM(CAST(0.6099821 AS MONEY)))) NULL, c2 TEXT );
+DROP TABLE t_issue_595;
 -- tests of column drop with partition tables and indexes using
 -- predicates and expressions.
 create table part_column_drop (

--- a/src/test/regress/sql/create_table.sql
+++ b/src/test/regress/sql/create_table.sql
@@ -962,6 +962,11 @@ drop table defcheck;
 CREATE UNLOGGED TABLE unlogged_toast (a text);
 TRUNCATE unlogged_toast;
 
+-- test https://github.com/cloudberrydb/cloudberrydb/issues/595
+CREATE TABLE t_issue_595(c0 DECIMAL UNIQUE DEFAULT (0.059636344153715326) PRIMARY KEY,
+	c1 money CHECK (((t_issue_595.c1)IS NOT DISTINCT FROM(CAST(0.6099821 AS MONEY)))) NULL, c2 TEXT );
+DROP TABLE t_issue_595;
+
 -- tests of column drop with partition tables and indexes using
 -- predicates and expressions.
 create table part_column_drop (


### PR DESCRIPTION
fix https://github.com/cloudberrydb/cloudberrydb/issues/595

It is introduced by commit Import Greenplum source code. Forget to read/out that expr them.

Authored-by: Zhang Mingli avamingli@gmail.com

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
