### PR TITLE
Fix: could not pull up equivalence class using projected target list

### DIFF
--- a/src/backend/cdb/cdbpullup.c
+++ b/src/backend/cdb/cdbpullup.c
@@ -124,7 +124,9 @@ pullUpExpr_mutator(Node *node, void *context)
 			foreach(cell, ctx->targetlist)
 			{
 				tlistexpr = (Expr *) lfirst(cell);
-
+				/* Ignore RelabelType nodes on top */
+				while (tlistexpr && IsA(tlistexpr, RelabelType))
+					tlistexpr = ((RelabelType *) tlistexpr)->arg;
 				/*
 				 * We don't use equal(), because we want to ignore typmod.
 				 * A projection sometimes loses typmod, and that's OK.

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -879,3 +879,18 @@ insert into fix_ao_truncate_last_sequence select 1, 1 from generate_series(1, 5)
 select count(*) from fix_ao_truncate_last_sequence;
 abort;
 
+create table fix_issue_605
+(
+c1 varchar(8),
+c2 varchar(12) collate "C",
+c3 varchar(10),
+c4 varchar(30)
+)
+with (appendonly=true,compresstype=zstd,compresslevel=5)
+distributed by (c1,c3,c4)
+partition by range(c1)
+(partition p1990 start('19900101') inclusive,
+default partition other
+);
+
+select c3::varchar from fix_issue_605 where c1='20190830' order by c2;

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -1741,3 +1741,21 @@ select count(*) from fix_ao_truncate_last_sequence;
 (1 row)
 
 abort;
+create table fix_issue_605
+(
+c1 varchar(8),
+c2 varchar(12) collate "C",
+c3 varchar(10),
+c4 varchar(30)
+)
+with (appendonly=true,compresstype=zstd,compresslevel=5)
+distributed by (c1,c3,c4)
+partition by range(c1)
+(partition p1990 start('19900101') inclusive,
+default partition other
+);
+select c3::varchar from fix_issue_605 where c1='20190830' order by c2;
+ c3 
+----
+(0 rows)
+


### PR DESCRIPTION
Ignore RelabelType nodes on top in pullUpExpr_mutator.

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #605
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
