### PR TITLE
Including complete snapshot message into SharedSnapshot

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1745,12 +1745,8 @@ setupQEDtxContext(DtxContextInfo *dtxContextInfo)
 				LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_SHARED);
 				elog(DTM_DEBUG5,
 					 "setupQEDtxContext inputs (part 2b):  shared local snapshot xid = " UINT64_FORMAT " "
-					 "(xmin: %u xmax: %u xcnt: %u) curcid: %d, QDxid = "UINT64_FORMAT"/%u",
+					 ", QDxid = "UINT64_FORMAT"/%u",
 					 U64FromFullTransactionId(SharedLocalSnapshotSlot->fullXid),
-					 SharedLocalSnapshotSlot->snapshot.xmin,
-					 SharedLocalSnapshotSlot->snapshot.xmax,
-					 SharedLocalSnapshotSlot->snapshot.xcnt,
-					 SharedLocalSnapshotSlot->snapshot.curcid,
 					 SharedLocalSnapshotSlot->distributedXid,
 					 SharedLocalSnapshotSlot->segmateSync);
 				LWLockRelease(SharedLocalSnapshotSlot->slotLock);

--- a/src/backend/storage/ipc/dsm.c
+++ b/src/backend/storage/ipc/dsm.c
@@ -44,6 +44,7 @@
 #include "utils/guc.h"
 #include "utils/memutils.h"
 #include "utils/resowner_private.h"
+#include "utils/sharedsnapshot.h"
 
 #define PG_DYNSHMEM_CONTROL_MAGIC		0x9a503d32
 
@@ -164,8 +165,9 @@ dsm_postmaster_startup(PGShmemHeader *shim)
 		dsm_cleanup_for_mmap();
 
 	/* Determine size for new control segment. */
-	maxitems = PG_DYNSHMEM_FIXED_SLOTS
-		+ PG_DYNSHMEM_SLOTS_PER_BACKEND * MaxBackends;
+	maxitems = PG_DYNSHMEM_FIXED_SLOTS +
+			   PG_DYNSHMEM_SLOTS_PER_BACKEND * MaxBackends +
+			   NUM_SHARED_SNAPSHOT_SLOTS * 2;
 	elog(DEBUG2, "dynamic shared memory system will support %u segments",
 		 maxitems);
 	segsize = dsm_control_bytes_needed(maxitems);

--- a/src/backend/utils/time/test/sharedsnapshot_test.c
+++ b/src/backend/utils/time/test/sharedsnapshot_test.c
@@ -59,9 +59,9 @@ test_boundaries_of_CreateSharedSnapshotArray(void **state)
 		 * Assert that every slot xip array falls inside the boundaries of the
 		 * allocated shared snapshot.
 		 */
-		assert_true((uint8_t *)s->snapshot.xip > (uint8_t *)fakeSharedSnapshotArray);
-		assert_true((uint8_t *)s->snapshot.xip < (((uint8_t *)fakeSharedSnapshotArray) +
-												sharedSnapshotShmemSize));
+		assert_true((uint8_t *)s > (uint8_t *)fakeSharedSnapshotArray);
+		assert_true((uint8_t *)s < (((uint8_t *)fakeSharedSnapshotArray) +
+									sharedSnapshotShmemSize));
 	}
 }
 

--- a/src/include/utils/sharedsnapshot.h
+++ b/src/include/utils/sharedsnapshot.h
@@ -13,6 +13,7 @@
 #ifndef SHAREDSNAPSHOT_H
 #define SHAREDSNAPSHOT_H
 
+#include "c.h"
 #include "storage/proc.h"
 #include "utils/combocid.h"
 #include "utils/snapshot.h"
@@ -23,7 +24,6 @@ typedef struct SnapshotDump
 	DistributedTransactionId distributedXid;
 	FullTransactionId localXid;
 	dsm_handle  handle;
-	dsm_segment *segment;
 } SnapshotDump;
 
 #define SNAPSHOTDUMPARRAYSZ 32
@@ -40,14 +40,16 @@ typedef struct SharedSnapshotSlot
 
 	volatile bool			ready;
 	volatile uint32			segmateSync;
-	SnapshotData	snapshot;
-	LWLock		   *slotLock;
 
-	volatile int    cur_dump_id;
-	volatile SnapshotDump    dump[SNAPSHOTDUMPARRAYSZ];
+	volatile dsm_handle		snapshot_handle;
+	uint32					snapshot_sz;
+	LWLock					*slotLock;
+
+	volatile int			cur_dump_id;
+	volatile SnapshotDump	dump[SNAPSHOTDUMPARRAYSZ];
 	/* for debugging only */
-	FullTransactionId	fullXid;
-	TimestampTz		startTimestamp;
+	FullTransactionId		fullXid;
+	TimestampTz				startTimestamp;
 } SharedSnapshotSlot;
 
 extern volatile SharedSnapshotSlot *SharedLocalSnapshotSlot;

--- a/src/include/utils/snapmgr.h
+++ b/src/include/utils/snapmgr.h
@@ -188,4 +188,7 @@ extern Snapshot RestoreSnapshot(char *start_address);
 extern void RestoreTransactionSnapshot(Snapshot snapshot, void *source_pgproc);
 
 extern Size EstimateSnapshotDataSpace(void);
+
+extern void ReadSharedLocalSnapshot(Snapshot snapshot);
+extern CommandId UpdateSharedLocalSnapshotCommandId(CommandId curcid);
 #endif							/* SNAPMGR_H */

--- a/src/test/isolation2/expected/sharedsnapshot.out
+++ b/src/test/isolation2/expected/sharedsnapshot.out
@@ -1,0 +1,34 @@
+2: CREATE OR REPLACE PROCEDURE test(bdate text, edate text) LANGUAGE PLPGSQL AS $$/*in func*/ BEGIN /*in func*/ EXECUTE format('ALTER TABLE dummy2 ADD PARTITION START (date ''%s'') INCLUSIVE END (date ''%s'') EXCLUSIVE', bdate, edate);/*in func*/ EXCEPTION/*in func*/ WHEN NO_DATA_FOUND THEN/*in func*/ RAISE EXCEPTION 'exception';/*in func*/ END;/*in func*/ $$ EXECUTE ON COORDINATOR;
+CREATE
+
+vacuum full pg_class;
+VACUUM
+
+2: CREATE TABLE dummy2 (id int, date date, amt decimal(10,2)) DISTRIBUTED BY (id) PARTITION BY RANGE (date) (START (date '2017-01-31') INCLUSIVE END (date '2017-02-01') EXCLUSIVE EVERY (INTERVAL '1 day') );
+CREATE
+
+2: begin;
+BEGIN
+2: savepoint a;
+SAVEPOINT
+2: call test('2020-01-01', '2020-01-02');
+CALL
+
+1: create table dummy1 as select sum(a.relnatts) from pg_class as a full join pg_class as b on a.relnatts = b.relnatts;
+CREATE 1
+1: drop table dummy1;
+DROP
+1: create table dummy1 as select sum(a.relnatts) from pg_class as a full join pg_class as b on a.relnatts = b.relnatts;
+CREATE 1
+
+2: commit;
+COMMIT
+2: call test('2020-01-02', '2020-01-03');
+CALL
+2: select count(1) from pg_inherits where inhparent = 'dummy2'::regclass;
+ count 
+-------
+ 3     
+(1 row)
+2: drop table dummy2, dummy1;
+DROP

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -318,3 +318,4 @@ test: uao/ao_unique_index_vacuum_column
 
 test: local_directory_table_mixed
 test: stat_activity_extended
+test: sharedsnapshot

--- a/src/test/isolation2/sql/sharedsnapshot.sql
+++ b/src/test/isolation2/sql/sharedsnapshot.sql
@@ -1,0 +1,29 @@
+2: CREATE OR REPLACE PROCEDURE test(bdate text, edate text) LANGUAGE PLPGSQL AS $$/*in func*/
+   BEGIN /*in func*/
+     EXECUTE format('ALTER TABLE dummy2 ADD PARTITION START (date ''%s'') INCLUSIVE END (date ''%s'') EXCLUSIVE', bdate, edate);/*in func*/
+     EXCEPTION/*in func*/
+   	WHEN NO_DATA_FOUND THEN/*in func*/
+   		RAISE EXCEPTION 'exception';/*in func*/
+   END;/*in func*/
+   $$ EXECUTE ON COORDINATOR;
+
+vacuum full pg_class;
+
+2: CREATE TABLE dummy2 (id int, date date, amt decimal(10,2))
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (date)
+(START (date '2017-01-31') INCLUSIVE
+END (date '2017-02-01') EXCLUSIVE EVERY (INTERVAL '1 day') );
+
+2: begin;
+2: savepoint a;
+2: call test('2020-01-01', '2020-01-02');
+
+1: create table dummy1 as select sum(a.relnatts) from pg_class as a full join pg_class as b on a.relnatts = b.relnatts; 
+1: drop table dummy1;
+1: create table dummy1 as select sum(a.relnatts) from pg_class as a full join pg_class as b on a.relnatts = b.relnatts; 
+
+2: commit;
+2: call test('2020-01-02', '2020-01-03');
+2: select count(1) from pg_inherits where inhparent = 'dummy2'::regclass;
+2: drop table dummy2, dummy1;


### PR DESCRIPTION
In our MPP query, the snapshot is synchronized by SharedSnapshot between QD/entrydb, QE writer gang/reader gang. The SharedSnapshot slot array is a range of share memory which is allocated in cluster instance start. Each session need to keep a slot until the session finished. Each snapshot includes distributed txn, local txn and also sub txn information. If all these infor save in shared memory, the array size is over 2GiB. For saving memory, the sub txn has not been included. Unfortunately, a data loss bug is introduced by this design.

```
In session a:
1. start a txn block (suppose txnid is 100) and using savepoint trap
   into sub txn (suppse txnid is 101).
2. create a new table

In session b:
3. trigger a command using entrydb to scan pg_class(suppose txnid is 102)
(e.g. `create table xxx select pg_class full join pg_class`).

4. drop the table and execute step 3 again (suppose txnid is 103 and 104)

In session a;
5: commit txn

The transaction is commit successful but the new table which was
created in the txn is loss.
```

The reason is that:
In session b step 4, the entrydb's snapshot is fetch from SharedSnapshot slot which is not including sub txn message. When the heapam fetch the tuple from the pg_class, it check each tuple's MVCC by the snapshot. The new table's record xmin is `101`, the snapshot xmin/xmax is `100`/`104`. Since txnid `101` can not find in snapshot either xip or subxip, and the clog do not have the commit log, MVCC validate the `101` transaction is Abort. `HEAP_XMIN_INVALID` a heap tuple level MVCC status bit is set to the pg_class record tuple.

After the session b scan, the record tuple sentence died.

To fix the bug, SharedSnapshot need to introduce sub txn back. For saving shared memory, the SharedSnapshot slot keep the snapshot into DSM.

Each SharedSnapshot slot hold a dsm_handle as the access point to the snapshot dsm. At the first use of a slot, the dsm is create, and the size is snapshot serialized size. The dsm is called `dsm_pin_segment` and `dsm_pin_mapping`, so its lifecycle is same as postmaster process. The dsm only destory and recreate again if new snapshot size is larger than dsm size.

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
