### PR TITLE
Check InterruptPending instead of InterruptPending in cdbdisp_dispatchX

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -1072,7 +1072,7 @@ cdbdisp_dispatchX(QueryDesc* queryDesc,
 	 *
 	 * On return, gangs have been allocated and CDBProcess lists have
 	 * been filled in the slice table.)
-	 * 
+	 *
 	 * Notice: This must be done before cdbdisp_buildPlanQueryParms
 	 */
 	AssignGangs(ds, queryDesc);
@@ -1164,7 +1164,7 @@ cdbdisp_dispatchX(QueryDesc* queryDesc,
 		{
 			if (ds->primaryResults->errcode)
 				break;
-			if (InterruptPending)
+			if (QueryCancelPending)
 				break;
 		}
 		SIMPLE_FAULT_INJECTOR("before_one_slice_dispatched");


### PR DESCRIPTION
When dispatching command to segments, if the 'cancelOnError' is true and the query is being canceled, it will bail out.
But before this pr, it check the 'InterruptPending' to see if there is a cancel request. When the process got a singal, like customer signal, not a query cancel request, it will cancle the query too. 

So I use the QueryCancelPending instead of InterrupPending here.
<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
