### PR TITLE
Replace usages of InterruptPending to the flag of query cancellation …

### DIFF
--- a/contrib/interconnect/tcp/ic_tcp.c
+++ b/contrib/interconnect/tcp/ic_tcp.c
@@ -2429,7 +2429,7 @@ waitOnOutbound(ChunkTransportStateEntry * pEntry)
 		if (conn_count == 0)
 			return;
 
-		if (InterruptPending || QueryFinishPending)
+		if (CancelRequested() || QueryFinishPending)
 		{
 #ifdef AMS_VERBOSE_LOGGING
 			elog(DEBUG3, "waitOnOutbound(): interrupt pending fast-track");
@@ -2451,7 +2451,7 @@ waitOnOutbound(ChunkTransportStateEntry * pEntry)
 		{
 			saved_err = errno;
 
-			if (InterruptPending || QueryFinishPending)
+			if (CancelRequested() || QueryFinishPending)
 				return;
 
 			/*

--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -533,7 +533,7 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 
 		while (PQisBusy(q->conn) && PQstatus(q->conn) == CONNECTION_OK)
 		{
-			if ((Gp_role == GP_ROLE_DISPATCH) && InterruptPending)
+			if ((Gp_role == GP_ROLE_DISPATCH) && CancelRequested())
 			{
 				PQrequestCancel(q->conn);
 			}

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -1164,7 +1164,7 @@ cdbdisp_dispatchX(QueryDesc* queryDesc,
 		{
 			if (ds->primaryResults->errcode)
 				break;
-			if (InterruptPending)
+			if (CancelRequested())
 				break;
 		}
 		SIMPLE_FAULT_INJECTOR("before_one_slice_dispatched");

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -6335,3 +6335,11 @@ disable_client_wait_timeout_interrupt(void)
 	if (DoingCommandRead)
 		DisableClientWaitTimeoutInterrupt();
 }
+
+/*
+ * Whether request on cancel or termination have arrived?
+ */
+inline bool
+CancelRequested() {
+	return InterruptPending && (ProcDiePending || QueryCancelPending);
+}

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -108,6 +108,7 @@ extern PGDLLIMPORT volatile int32 CritSectionCount;
 
 /* in tcop/postgres.c */
 extern void ProcessInterrupts(const char* filename, int lineno);
+extern bool CancelRequested();
 
 /* Hook get notified when QueryCancelPending or ProcDiePending is raised */
 typedef void (*cancel_pending_hook_type) (void);


### PR DESCRIPTION
Cherry-pick from greenplum

Currently some communication routines between master and segments performing polling of messages from segments rely on InterruptPending flag in detection of cancel or terminating events. This flag is used to define some interruption in CHECK_FOR_INTERRUPTS() routine. Up to some time this flag was closely assigned with some exceptional case, more often with cancel or termination request. But as GPDB merges with newest versions of PostgreSQL, there are more and more cases where interruption begins to denote some not certainly causing error thing, e.g., periodic check of connectivity with client. For this reason it becomes necessary to redefine the usages of InterruptPending flag to no longer erroneously evaluate the set InterruptPending flag as cancel request.

Current patch fixes four places of InterruptPending usage in waiting loops of master-segments communication. Some waiting loops might last a long time and injecting of CHECK_FOR_INTERRUPTS() call to there is necessary to not postpone interruption requests to much. But in other loops the waiting is short enough if connectivity between master and segments is preserved, therefore the check on cancellation or termination in those loops is enough. The case of connection abort or hanging on segments side have to be handled in separate work since it will require to rewrite the logic in waiting loop.

This PR is the prerequisite for https://github.com/greenplum-db/gpdb/pull/12223

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
