### PR TITLE
Fix test parallel_retrieve_cursor/explain

### DIFF
--- a/src/test/isolation2/input/parallel_retrieve_cursor/explain.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/explain.source
@@ -41,6 +41,8 @@ EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * 
 VACUUM pg_class;
 
 -- Test for system table which is accessible on coordinator
+-- analyze pg_class to avoid generating different plan
+VACUUM ANALYZE pg_class;
 EXPLAIN (VERBOSE, COSTS false) DECLARE c1 CURSOR FOR SELECT * FROM pg_class;
 
 -- Test: explain output: Endpoint info (on coordinator/on some segments/on all segments)

--- a/src/test/isolation2/output/parallel_retrieve_cursor/explain.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/explain.source
@@ -110,6 +110,9 @@ VACUUM pg_class;
 VACUUM
 
 -- Test for system table which is accessible on coordinator
+-- analyze pg_class to avoid generating different plan
+VACUUM ANALYZE pg_class;
+VACUUM
 EXPLAIN (VERBOSE, COSTS false) DECLARE c1 CURSOR FOR SELECT * FROM pg_class;
  QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                         
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The stats info of pg_class maybe changged when the autovacuum running, and can let the explain command generate different plan. So analyze pg_class
before explain command to make the case stable.

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
