### PR TITLE
Expose two functions to convert string to varchar/bpchar

### DIFF
--- a/src/backend/utils/adt/varchar.c
+++ b/src/backend/utils/adt/varchar.c
@@ -122,7 +122,7 @@ anychar_typmodout(int32 typmod)
  * If the input string is too long, raise an error, unless the extra
  * characters are spaces, in which case they're truncated.  (per SQL)
  */
-static BpChar *
+BpChar *
 bpchar_input(const char *s, size_t len, int32 atttypmod)
 {
 	BpChar	   *result;
@@ -450,7 +450,7 @@ bpchartypmodout(PG_FUNCTION_ARGS)
  * Uses the C string to text conversion function, which is only appropriate
  * if VarChar and text are equivalent types.
  */
-static VarChar *
+VarChar *
 varchar_input(const char *s, size_t len, int32 atttypmod)
 {
 	VarChar    *result;

--- a/src/include/utils/builtins.h
+++ b/src/include/utils/builtins.h
@@ -92,6 +92,8 @@ extern void generate_operator_clause(fmStringInfo buf,
 
 /* varchar.c */
 extern int	bpchartruelen(char *s, int len);
+extern BpChar *bpchar_input(const char *s, size_t len, int32 atttypmod);
+extern VarChar *varchar_input(const char *s, size_t len, int32 atttypmod);
 
 /* popular functions from varlena.c */
 extern text *cstring_to_text(const char *s);


### PR DESCRIPTION
Extensions require converting cstring to varchar or bpchar. When converting to varchar, trailing spaces are removed. When converting to bpchar, the remaining bytes are padded with spaces.

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
