### PR TITLE
Refactor parallel scan node and framework

### DIFF
--- a/src/backend/access/transam/parallel.c
+++ b/src/backend/access/transam/parallel.c
@@ -1671,36 +1671,6 @@ GpParallelDSMHashSize(void)
 }
 
 
-void *
-GpFetchParallelDSMEntry(ParallelEntryTag tag, int plan_node_id)
-{
-	GpParallelDSMEntry *entry;
-	shm_toc    *toc;
-	bool found = false;
-
-	entry = (GpParallelDSMEntry *)
-		hash_search(GpParallelDSMHash,
-				&tag,
-				HASH_FIND,
-				&found);
-	Assert(found);
-
-	if (entry->pid == MyProcPid)
-	{
-		toc = entry->toc;
-	}
-	else
-	{
-		Assert(ParallelSession->segment);
-		toc = shm_toc_attach(CBDB_PARALLEL_MAGIC, dsm_segment_address(ParallelSession->segment));
-	}
-
-	Assert(toc != NULL);
-
-	return shm_toc_lookup(toc, plan_node_id, true);
-}
-
-
 void GpDestroyParallelDSMEntry()
 {
 	GpParallelDSMEntry *entry;

--- a/src/backend/executor/nodeIndexonlyscan.c
+++ b/src/backend/executor/nodeIndexonlyscan.c
@@ -87,33 +87,16 @@ IndexOnlyNext(IndexOnlyScanState *node)
 
 	if (scandesc == NULL)
 	{
-		if (node->ss.ps.plan->parallel_aware && estate->useMppParallelMode)
-		{
-			ParallelIndexScanDesc piscan;
-			ParallelEntryTag tag;
-			int localSliceId = LocallyExecutingSliceIndex(estate);
-			INIT_PARALLELENTRYTAG(tag, gp_command_count, localSliceId, gp_session_id);
-			piscan = GpFetchParallelDSMEntry(tag, node->ss.ps.plan->plan_node_id);
-			Assert(piscan);
-			scandesc = index_beginscan_parallel(node->ss.ss_currentRelation,
-								 node->ioss_RelationDesc,
-								 node->ioss_NumScanKeys,
-								 node->ioss_NumOrderByKeys,
-								 piscan);
-		}
-		else
-		{
-			/*
-			* We reach here if the index only scan is not parallel, or if we're
-			* serially executing an index only scan that was planned to be
-			* parallel.
-			*/
-			scandesc = index_beginscan(node->ss.ss_currentRelation,
-									node->ioss_RelationDesc,
-									estate->es_snapshot,
-									node->ioss_NumScanKeys,
-									node->ioss_NumOrderByKeys);
-		}
+		/*
+		* We reach here if the index only scan is not parallel, or if we're
+		* serially executing an index only scan that was planned to be
+		* parallel.
+		*/
+		scandesc = index_beginscan(node->ss.ss_currentRelation,
+								node->ioss_RelationDesc,
+								estate->es_snapshot,
+								node->ioss_NumScanKeys,
+								node->ioss_NumOrderByKeys);
 
 		node->ioss_ScanDesc = scandesc;
 

--- a/src/backend/executor/nodeIndexscan.c
+++ b/src/backend/executor/nodeIndexscan.c
@@ -107,35 +107,17 @@ IndexNext(IndexScanState *node)
 
 	if (scandesc == NULL)
 	{
-		if (node->ss.ps.plan->parallel_aware && estate->useMppParallelMode)
-		{
-			ParallelIndexScanDesc piscan;
-			ParallelEntryTag tag;
-			int localSliceId = LocallyExecutingSliceIndex(estate);
-			INIT_PARALLELENTRYTAG(tag, gp_command_count, localSliceId, gp_session_id);
-			piscan = GpFetchParallelDSMEntry(tag, node->ss.ps.plan->plan_node_id);
-			Assert(piscan);
-			scandesc = index_beginscan_parallel(node->ss.ss_currentRelation,
-								 node->iss_RelationDesc,
-								 node->iss_NumScanKeys,
-								 node->iss_NumOrderByKeys,
-								 piscan);
-			node->iss_ScanDesc = scandesc;
-		}
-		else
-		{
-			/*
-			* We reach here if the index scan is not parallel, or if we're
-			* serially executing an index scan that was planned to be parallel.
-			*/
-			scandesc = index_beginscan(node->ss.ss_currentRelation,
-									node->iss_RelationDesc,
-									estate->es_snapshot,
-									node->iss_NumScanKeys,
-									node->iss_NumOrderByKeys);
+		/*
+		* We reach here if the index scan is not parallel, or if we're
+		* serially executing an index scan that was planned to be parallel.
+		*/
+		scandesc = index_beginscan(node->ss.ss_currentRelation,
+								node->iss_RelationDesc,
+								estate->es_snapshot,
+								node->iss_NumScanKeys,
+								node->iss_NumOrderByKeys);
 
-			node->iss_ScanDesc = scandesc;
-		}
+		node->iss_ScanDesc = scandesc;
 
 		/*
 		 * If no run-time keys to calculate or they are ready, go ahead and

--- a/src/include/access/parallel.h
+++ b/src/include/access/parallel.h
@@ -121,7 +121,6 @@ extern bool EstimateGpParallelDSMEntrySize(PlanState *planstate, ParallelContext
 
 extern bool InitializeGpParallelDSMEntry(PlanState *node, ParallelContext *pctx);
 extern bool InitializeGpParallelWorkers(PlanState *planstate, ParallelWorkerContext *pwcxt);
-extern void* GpFetchParallelDSMEntry(ParallelEntryTag tag, int plan_node_id);
 
 extern void GpDestroyParallelDSMEntry(void);
 


### PR DESCRIPTION
Seq scan, Index scan, Indexonly scan also use a unified approach.

step 1,calc space in leader : EstimateGpParallelDSMEntrySize
step 2,Init leader DSM: InitializeGpParallelDSMEntry
step 3,Init worker DSM : InitializeGpParallelWorkers

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
