### PR TITLE
Update appendonly_compaction.c, add helpfull debug via Debug_appendon…

### DIFF
--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -703,6 +703,9 @@ AppendOptimizedTruncateToEOF(Relation aorel)
 
 	relname = RelationGetRelationName(aorel);
 
+	elogif(Debug_appendonly_print_compaction, LOG,
+		   "Truncating AO relation %s block-file segments to its EOF", relname);
+
 	/*
 	 * The algorithm below for choosing a target segment is not concurrent-safe.
 	 * Grab a lock to serialize.
@@ -801,6 +804,9 @@ AppendOnlyCompact(Relation aorel,
 	Assert(Gp_role == GP_ROLE_EXECUTE || Gp_role == GP_ROLE_UTILITY);
 
 	relname = RelationGetRelationName(aorel);
+	
+	elogif(Debug_appendonly_print_compaction, LOG,
+		   "Compact AO relation %s block-file segment %d", relname, compaction_segno);
 
 	/* Fetch under the write lock to get latest committed eof. */
 	fsinfo = GetFileSegInfo(aorel, appendOnlyMetaDataSnapshot, compaction_segno, true);


### PR DESCRIPTION
…ly_print_compaction

Recently have been debugging some unrelated issue, and i happened to notice that `Debug_appendonly_print_compaction` printing gone in CBDB (it was very helpfull in GPDB6) So, I propose to bring it back.

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
