### PR TITLE
gpexpand: TRUNCATE coordinator-only tables for cleanup

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -33,7 +33,8 @@ try:
     from gppylib.system import configurationInterface, configurationImplGpdb
     from gppylib.system.environment import GpCoordinatorEnvironment
     from pgdb import DatabaseError
-    from gppylib.gpcatalog import COORDINATOR_ONLY_TABLES
+    from gppylib.gpcatalog import COORDINATOR_ONLY_TABLES_MAPPED
+    from gppylib.gpcatalog import COORDINATOR_ONLY_TABLES_NON_MAPPED
     from gppylib.operations.package import SyncPackages
     from gppylib.operations.utils import ParallelOperation
     from gppylib.parseutils import line_reader, check_values, canonicalize_address
@@ -1416,11 +1417,13 @@ class gpexpand:
 
 
         """
-        Build the list of delete statements based on the COORDINATOR_ONLY_TABLES
-        defined in gpcatalog.py
+        Build the list of DELETE and TRUNCATE statements based on the subset of
+        COORDINATOR_ONLY_TABLES defined in gpcatalog.py. Mapped tables cannot
+        be TRUNCATEd, and we will have DELETE from them.
         """
-        statements = ["delete from pg_catalog.%s" % tab for tab in COORDINATOR_ONLY_TABLES]
-
+        delete_statements = ["delete from pg_catalog.%s" % tab for tab in COORDINATOR_ONLY_TABLES_MAPPED]
+        truncate_statements = ["truncate pg_catalog.%s" % tab for tab in COORDINATOR_ONLY_TABLES_NON_MAPPED]
+        statements = delete_statements + truncate_statements
         """
           Connect to each database in the new segments, and clean up the catalog tables.
         """

--- a/gpMgmt/bin/gppylib/gpcatalog.py
+++ b/gpMgmt/bin/gppylib/gpcatalog.py
@@ -21,8 +21,32 @@ logger = gplog.get_default_logger()
 class GPCatalogException(Exception):
     pass
 
-# Hard coded since "coordinator only" is not defined in the catalog
-COORDINATOR_ONLY_TABLES = [
+# The following lists capture "coordinator only" tables. They are hard-coded
+# since there is no notion of "coordinator only" defined in the catalog.
+# Depending on whether a relation is mapped or not, we have 2 sub-lists.
+# See RelationIsMapped().
+
+COORDINATOR_ONLY_TABLES_MAPPED = [
+    'pg_auth_time_constraint',
+    'pg_shdescription',
+    'gp_configuration_history',
+    'gp_segment_configuration',
+    'pg_stat_last_shoperation',
+    'gp_matview_aux',
+    'gp_matview_tables',
+]
+
+COORDINATOR_ONLY_TABLES_NON_MAPPED = [
+    'pg_description',
+    'pg_stat_last_operation',
+    'pg_statistic',
+    'pg_statistic_ext',
+    'pg_statistic_ext_data',
+    'gp_partition_template', # GPDB_12_MERGE_FIXME: is gp_partition_template intentionally missing from segments?
+    'pg_event_trigger'
+]
+
+COORDINATOR_ONLY_TABLES = [ # TODO: Why 'gp_segment_configuration' is missing here?
     'gp_configuration_history',
     'pg_auth_time_constraint',
     'pg_description',


### PR DESCRIPTION
For a subset of coordinator only tables (non-mapped relations), we can go ahead and use TRUNCATE instead of DELETE, to gain a performance boost.

This is a cherry-pick of [similar commit](https://github.com/greenplum-db/gpdb-archive/commit/f55885f9b4e9).
