### PR TITLE
Implement 3-phase aggregation with DEDUP HashAgg for DISTINCT.

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -270,6 +270,7 @@ bool		gp_cte_sharing = false;
 bool		gp_enable_relsize_collection = false;
 bool		gp_recursive_cte = true;
 bool		gp_eager_two_phase_agg = false;
+bool		gp_eager_distinct_dedup = false;
 bool		gp_force_random_redistribution = false;
 
 /* Optimizer related gucs */
@@ -1826,6 +1827,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_eager_two_phase_agg,
+		false, NULL, NULL
+	},
+
+	{
+		{"gp_eager_distinct_dedup", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("Eager a 3-phase agg with deduplication for DISTINCT aggregations."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_eager_distinct_dedup,
 		false, NULL, NULL
 	},
 

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -690,6 +690,8 @@ extern bool		gp_statistics_use_fkeys;
 /* Allow user to force tow stage agg */
 extern bool     gp_eager_two_phase_agg;
 
+extern bool     gp_eager_distinct_dedup;
+
 /* Force redistribution of insert into randomly-distributed table */
 extern bool     gp_force_random_redistribution;
 

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -172,6 +172,7 @@
 		"gp_dtx_recovery_interval",
 		"gp_dtx_recovery_prepared_period",
 		"gp_dynamic_partition_pruning",
+		"gp_eager_distinct_dedup",
 		"gp_eager_two_phase_agg",
 		"gp_enable_agg_distinct",
 		"gp_enable_agg_distinct_pruning",

--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -321,22 +321,24 @@ select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dqa_t1.d = dqa_t2.d gr
 (56 rows)
 
 explain (costs off) select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dqa_t1.d = dqa_t2.d group by dqa_t2.dt;
-                         QUERY PLAN
-------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  HashAggregate
+   ->  Finalize HashAggregate
          Group Key: dqa_t2.dt
          ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Hash Key: dqa_t2.dt
-               ->  HashAggregate
-                     Group Key: dqa_t2.dt, dqa_t1.d
-                     ->  Hash Join
-                           Hash Cond: (dqa_t1.d = dqa_t2.d)
-                           ->  Seq Scan on dqa_t1
-                           ->  Hash
-                                 ->  Seq Scan on dqa_t2
+               ->  Partial HashAggregate
+                     Group Key: dqa_t2.dt
+                     ->  HashAggregate
+                           Group Key: dqa_t2.dt, dqa_t1.d
+                           ->  Hash Join
+                                 Hash Cond: (dqa_t1.d = dqa_t2.d)
+                                 ->  Seq Scan on dqa_t1
+                                 ->  Hash
+                                       ->  Seq Scan on dqa_t2
  Optimizer: Postgres query optimizer
-(13 rows)
+(15 rows)
 
 -- Distinct keys are not distribution keys
 select count(distinct c) from dqa_t1;
@@ -2338,3 +2340,61 @@ explain (verbose, costs off) select count(distinct (b)::text) as b, count(distin
  Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
 (19 rows)
 
+-- Test 3-phase agg for DISTINCT on distribution keys
+-- or DISTINCT when GROUP BY on distribution keys
+create table t_issue_659(a int, b int) using ao_row;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t_issue_659 select i from generate_series(1, 1000) i;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+analyze t_issue_659;
+explain(costs off)
+select count(distinct a) from t_issue_659;
+                   QUERY PLAN                   
+------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on t_issue_659
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+select count(distinct a) from t_issue_659;
+ count 
+-------
+  1000
+(1 row)
+
+set gp_eager_distinct_dedup = on;
+explain(costs off)
+select count(distinct a) from t_issue_659;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  HashAggregate
+                     Group Key: a
+                     ->  Seq Scan on t_issue_659
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select count(distinct a) from t_issue_659;
+ count 
+-------
+  1000
+(1 row)
+
+reset gp_eager_distinct_dedup;
+drop table t_issue_659;

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -2487,3 +2487,59 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
  Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
 (19 rows)
 
+-- Test 3-phase agg for DISTINCT on distribution keys
+-- or DISTINCT when GROUP BY on distribution keys
+create table t_issue_659(a int, b int) using ao_row;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t_issue_659 select i from generate_series(1, 1000) i;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+analyze t_issue_659;
+explain(costs off)
+select count(distinct a) from t_issue_659;
+                   QUERY PLAN                   
+------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on t_issue_659
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+select count(distinct a) from t_issue_659;
+ count 
+-------
+  1000
+(1 row)
+
+set gp_eager_distinct_dedup = on;
+explain(costs off)
+select count(distinct a) from t_issue_659;
+                   QUERY PLAN                   
+------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on t_issue_659
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+select count(distinct a) from t_issue_659;
+ count 
+-------
+  1000
+(1 row)
+
+reset gp_eager_distinct_dedup;
+drop table t_issue_659;

--- a/src/test/regress/sql/gp_dqa.sql
+++ b/src/test/regress/sql/gp_dqa.sql
@@ -397,3 +397,30 @@ explain (verbose, costs off) select count(distinct (b)::text) as b, count(distin
 -- column '(a)::integer::varchar' as part of hash-key in Redistribute-Motion.
 select count(distinct (b)::text) as b, count(distinct (a)::int::varchar) as a from dqa_f3;
 explain (verbose, costs off) select count(distinct (b)::text) as b, count(distinct (a)::int::varchar) as a from dqa_f3;
+
+-- Test 3-phase agg for DISTINCT on distribution keys
+-- or DISTINCT when GROUP BY on distribution keys
+create table t_issue_659(a int, b int) using ao_row;
+insert into t_issue_659 select i from generate_series(1, 1000) i;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+insert into t_issue_659 select * from t_issue_659;
+analyze t_issue_659;
+explain(costs off)
+select count(distinct a) from t_issue_659;
+select count(distinct a) from t_issue_659;
+set gp_eager_distinct_dedup = on;
+explain(costs off)
+select count(distinct a) from t_issue_659;
+select count(distinct a) from t_issue_659;
+reset gp_eager_distinct_dedup;
+drop table t_issue_659;


### PR DESCRIPTION
When DISTINCT on distribution keys or DISTINCT with GROUP BY on distributions keys, we could also add a HashAgg node to do a pre-dedup before aggregation.

A 3-phase aggregation is as:
```sql
explain(costs off)
select count(distinct a) from t_issue_659;
                   QUERY PLAN
-------------------------------------------------
 Finalize Aggregate
   ->  Gather Motion 3:1  (slice1; segments: 3)
         ->  Partial Aggregate
               ->  HashAggregate
                     Group Key: a
                     ->  Seq Scan on t_issue_659
 Optimizer: Postgres query optimizer
(7 rows)
```
HashAggregate node may eliminate tuples and have a win compared to two-phase aggregation with Partial and Final Aggregate.

The effect is closely related to the data distribution of distinct values across segments, and we introduce a new GUC to make use win.

**set gp_eager_distinct_dedup = on;**

If set, planner will eager to use our 3-phase aggregate plan.

This also works for join:
```sql
explain (costs off) select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dqa_t1.d = dqa_t2.d group by dqa_t2.dt;
                            QUERY PLAN
------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   ->  Finalize HashAggregate
         Group Key: dqa_t2.dt
         ->  Redistribute Motion 3:3  (slice2; segments: 3)
               Hash Key: dqa_t2.dt
               ->  Partial HashAggregate
                     Group Key: dqa_t2.dt
                     ->  HashAggregate
                           Group Key: dqa_t2.dt, dqa_t1.d
                           ->  Hash Join
                                 Hash Cond: (dqa_t1.d = dqa_t2.d)
                                 ->  Seq Scan on dqa_t1
                                 ->  Hash
                                       ->  Seq Scan on dqa_t2
 Optimizer: Postgres query optimizer
(15 rows)
```
Authored-by: Zhang Mingli avamingli@gmail.com

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
