### PR TITLE
fix incorrect first Tid during index scan which using bitmap index

### DIFF
--- a/src/backend/access/bitmap/bitmaputil.c
+++ b/src/backend/access/bitmap/bitmaputil.c
@@ -284,6 +284,7 @@ _bitmap_findnexttids(BMBatchWords *words, BMIterateResult *result,
 			result->nextTid += fillLength * BM_HRL_WORD_SIZE;
 			result->lastScanWordNo++;
 			words->nwords--;
+			words->firstTid += fillLength * BM_HRL_WORD_SIZE;
 			result->lastScanPos = 0;
 			continue;
 		}
@@ -303,6 +304,7 @@ _bitmap_findnexttids(BMBatchWords *words, BMIterateResult *result,
 				nfillwords--;
 				/* update fill word to reflect expansion */
 				words->cwords[result->lastScanWordNo]--;
+				words->firstTid += BM_HRL_WORD_SIZE;
 			}
 
 			if (nfillwords == 0)
@@ -342,6 +344,7 @@ _bitmap_findnexttids(BMBatchWords *words, BMIterateResult *result,
 				else
 				{
 					result->nextTid += BM_HRL_WORD_SIZE;
+					words->firstTid += BM_HRL_WORD_SIZE;
 					/* start scanning a new word */
 					words->nwords--;
 					result->lastScanWordNo++;

--- a/src/test/regress/expected/bitmap_index.out
+++ b/src/test/regress/expected/bitmap_index.out
@@ -972,3 +972,29 @@ select * from foo where a = 1 or a = any(null::int[]);
 (1 row)
 
 drop table foo;
+-- test for compressed bitmap index ; see https://github.com/cloudberrydb/cloudberrydb/pull/679
+SET enable_seqscan = OFF;
+SET enable_indexscan = ON;
+SET enable_bitmapscan = OFF;
+create table bm_test_ao (i int, j int, k int) WITH (appendonly=true) distributed by (k) ;
+create index bm_test_ao_i_idx on bm_test_ao using bitmap(i);
+insert into bm_test_ao select i, 1, 1 from
+generate_series(1, 65535) g, generate_series(1, 4) i;
+explain select count(*) from bm_test_ao where i =2;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=80.97..80.98 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=80.91..80.96 rows=3 width=8)
+         ->  Partial Aggregate  (cost=80.91..80.92 rows=1 width=8)
+               ->  Index Scan using bm_test_ao_i_idx on bm_test_ao  (cost=0.00..80.84 rows=26 width=0)
+                     Index Cond: (i = 2)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select count(*) from bm_test_ao where i = 2;
+ count 
+-------
+ 65535
+(1 row)
+
+DROP TABLE bm_test_ao;

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -978,3 +978,30 @@ select * from foo where a = 1 or a = any(null::int[]);
 (1 row)
 
 drop table foo;
+-- test for compressed bitmap index ; see https://github.com/cloudberrydb/cloudberrydb/pull/679
+SET enable_seqscan = OFF;
+SET enable_indexscan = ON;
+SET enable_bitmapscan = OFF;
+create table bm_test_ao (i int, j int, k int) WITH (appendonly=true) distributed by (k) ;
+create index bm_test_ao_i_idx on bm_test_ao using bitmap(i);
+insert into bm_test_ao select i, 1, 1 from
+generate_series(1, 65535) g, generate_series(1, 4) i;
+explain select count(*) from bm_test_ao where i =2;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..391.30 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..391.30 rows=1 width=1)
+         ->  Bitmap Heap Scan on bm_test_ao  (cost=0.00..391.30 rows=1 width=1)
+               Recheck Cond: (i = 2)
+               ->  Bitmap Index Scan on bm_test_ao_i_idx  (cost=0.00..0.00 rows=0 width=0)
+                     Index Cond: (i = 2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+select count(*) from bm_test_ao where i = 2;
+ count 
+-------
+ 65535
+(1 row)
+
+DROP TABLE bm_test_ao;

--- a/src/test/regress/sql/bitmap_index.sql
+++ b/src/test/regress/sql/bitmap_index.sql
@@ -403,3 +403,19 @@ select * from foo where a = 1 and a = any(null::int[]);
 select * from foo where a = 1 or a = any(null::int[]);
 
 drop table foo;
+
+-- test for compressed bitmap index ; see https://github.com/cloudberrydb/cloudberrydb/pull/679
+SET enable_seqscan = OFF;
+SET enable_indexscan = ON;
+SET enable_bitmapscan = OFF;
+
+create table bm_test_ao (i int, j int, k int) WITH (appendonly=true) distributed by (k) ;
+create index bm_test_ao_i_idx on bm_test_ao using bitmap(i);
+insert into bm_test_ao select i, 1, 1 from
+generate_series(1, 65535) g, generate_series(1, 4) i;
+
+explain select count(*) from bm_test_ao where i =2;
+
+select count(*) from bm_test_ao where i = 2;
+
+DROP TABLE bm_test_ao;


### PR DESCRIPTION
### Change logs
the _bitmap_findnexttids function has issues. It incorrectly skips data in some cases

The BMIterateResultstructure can store a maximum of 16 * 1024 = 16,384 TIDs, and in each iteration, we can return at most 16,384 TIDs. However, the BMBatchWordsstructure can store 3,968 words, each of which can be compressed (as specifiedby BMBatchWords hwords; see details in src/backend/access/bitmap/README). The maximum number of TIDs that can be stored in one word is equal to BM_MAX_TUPLES_PER_PAGE, which is an integer multiple of 64 and greater than 16,384.

This PR aims to fix the bug in this case. If words->cwords[0] is compressed and its length exceeds 16,384, the TIDs greater than 16,384 in cwords[0] will be skipped during access.

the first call:
param words:
{
      firstTid = 1;
      cwords[0] = 0x80000200
      hwords[0] = 0xc0000000
}

result:
{
      nextTid = 1;
      lastScanWordNo = 0;
      nextTids = (0, repeat 16384 times);
      numOfTids = 0;
      nextTidLoc 1;
}
After the first call:
word:
{
      firstTid = 1;
      cwords[0] = 0x80000100
      hwords[0] = 0xc0000000
}
result:
{
      nextTid = 16385;
      lastScanWordNo = 0;
      nextTids = (1, 2, 3,..., 16384);
      numOfTids = 16384;
      nextTidLoc = 1;
}

the second call:
word:
{
      firstTid = 1;
      cwords[0] = 0x80000100
      hwords[0] = 0xc0000000
}
result:
{
      nextTid = 16385;
      lastScanWordNo = 0;
      nextTids = (1, 2, 3,..., 16384);
      numOfTids = 16384;
      nextTidLoc = 16385;
}

words->firstTid is still equal to 1, but cwords[0] has already decremented the number of TIDs returned during the first call (0x100 * 64 = 16,384). At this point, firstTid does not match the actual data in cwords, and it is less than result->NextTid. The _bitmap_catchup_to_next_tid function will adjust firstTid, and simultaneously decrement cwords[0] by 16,384, resulting in TIDs 16,385 to 32,768 being skipped.

We need to ensure that firstTid is in the correct position. Therefore, every time we modify cwords, whether iterating by bit within a single word or skipping an entire word, we must synchronize the update of firstTid.

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
