### PR TITLE
Get back gp_distinct_plans tests.

### DIFF
--- a/src/test/regress/expected/gp_distinct_plans.out
+++ b/src/test/regress/expected/gp_distinct_plans.out
@@ -41,11 +41,11 @@ explain select distinct b from distinct_test;
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=46.86..46.96 rows=6 width=4)
-   ->  Finalize HashAggregate  (cost=46.86..46.88 rows=2 width=4)
+   ->  HashAggregate  (cost=46.86..46.88 rows=2 width=4)
          Group Key: b
          ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=46.67..46.85 rows=6 width=4)
                Hash Key: b
-               ->  Partial HashAggregate  (cost=46.67..46.73 rows=6 width=4)
+               ->  HashAggregate  (cost=46.67..46.73 rows=6 width=4)
                      Group Key: b
                      ->  Seq Scan on distinct_test  (cost=0.00..38.33 rows=3333 width=4)
  Optimizer: Postgres query optimizer
@@ -139,11 +139,11 @@ select distinct a, b from distinct_test;
 explain select distinct b from distinct_test;
                                        QUERY PLAN                                        
 -----------------------------------------------------------------------------------------
- Finalize GroupAggregate  (cost=233.38..250.45 rows=6 width=4)
+ GroupAggregate  (cost=233.38..250.45 rows=6 width=4)
    Group Key: b
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=233.38..250.35 rows=18 width=4)
          Merge Key: b
-         ->  Partial GroupAggregate  (cost=233.38..250.11 rows=6 width=4)
+         ->  GroupAggregate  (cost=233.38..250.11 rows=6 width=4)
                Group Key: b
                ->  Sort  (cost=233.38..241.71 rows=3333 width=4)
                      Sort Key: b
@@ -227,11 +227,11 @@ select distinct a, b from distinct_test;
 explain select distinct b from distinct_test;
                                                      QUERY PLAN                                                      
 ---------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate  (cost=0.16..197.23 rows=6 width=4)
+ GroupAggregate  (cost=0.16..197.23 rows=6 width=4)
    Group Key: b
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.16..197.13 rows=18 width=4)
          Merge Key: b
-         ->  Partial GroupAggregate  (cost=0.16..196.89 rows=6 width=4)
+         ->  GroupAggregate  (cost=0.16..196.89 rows=6 width=4)
                Group Key: b
                ->  Index Only Scan using distinct_test_b_idx on distinct_test  (cost=0.16..188.49 rows=3333 width=4)
  Optimizer: Postgres query optimizer

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -104,6 +104,8 @@ test: dtm_retry
 # serializable transactions (may conflict with AO vacuum operations).
 test: rangefuncs_cdb gp_dqa subselect_gp subselect_gp2 gp_transactions olap_group olap_window_seq sirv_functions appendonly create_table_distpol alter_distpol_dropped query_finish partial_table subselect_gp_indexes
 
+test: gp_distinct_plans
+
 # 'partition' runs for a long time, so try to keep it together with other
 # long-running tests.
 test: partition partition1 partition_indexing partition_storage partition_ddl partition_with_user_defined_function partition_unlogged partition_subquery partition_with_user_defined_function_that_truncates


### PR DESCRIPTION
I found this  case is never really tested when develop #676. 

The gp_distinct_plans is added by commit 18188949bcd, but it forgot to test in schedule.
So the case is never tested.
Get it back and fix the plan of distinct.

Authored-by: Zhang Mingli avamingli@gmail.com

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
