### PR TITLE
Fast path to REFRESH materialized view.

### DIFF
--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -388,27 +388,6 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 	relowner = matviewRel->rd_rel->relowner;
 
 	/*
-	 * Fastpath to REFRESH a view:
-	 * avoid do the real REFRESH if the data of view
-	 * is up to date. The data should be the logically same as after
-	 * REFRESH when there is data changed since latest REFRESH.
-	 * In that case we may save a lot, ex: a cron task REFRESH view periodically
-	 * or manually executed by users each time.
-	 *
-	 * Set this feature default to true, but let uesrs decide if they intend
-	 * to do a real REFRESH.
-	 */
-	if (gp_enable_refresh_fast_path &&
-		!RelationIsIVM(matviewRel) &&
-		!stmt->skipData &&
-		MatviewIsGeneralyUpToDate(matviewOid))
-	{
-		ObjectAddressSet(address, RelationRelationId, matviewOid);
-		table_close(matviewRel, NoLock);
-		return address;
-	}
-
-	/*
 	 * Switch to the owner's userid, so that any functions are run as that
 	 * user.  Also lock down security-restricted operations and arrange to
 	 * make GUC variable changes local to this command.
@@ -438,6 +417,27 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 				(errcode(ERRCODE_SYNTAX_ERROR),
 				 errmsg("%s and %s options cannot be used together",
 						"CONCURRENTLY", "WITH NO DATA")));
+
+	/*
+	 * Fast path to REFRESH a view:
+	 * avoid do the real REFRESH if the data of view
+	 * is up to date. The data should be the logically same as after
+	 * REFRESH when there is data changed since latest REFRESH.
+	 * In that case we may save a lot, ex: a cron task REFRESH view periodically
+	 * or manually executed by users each time.
+	 *
+	 * Set this feature default to true, but let uesrs decide if they intend
+	 * to do a real REFRESH.
+	 */
+	if (gp_enable_refresh_fast_path &&
+		!RelationIsIVM(matviewRel) &&
+		!stmt->skipData &&
+		MatviewIsGeneralyUpToDate(matviewOid))
+	{
+		ObjectAddressSet(address, RelationRelationId, matviewOid);
+		table_close(matviewRel, NoLock);
+		return address;
+	}
 
 	viewQuery = get_matview_query(matviewRel);
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -448,6 +448,9 @@ bool		gp_log_endpoints = false;
 /* optional reject to  parse ambigous 5-digits date in YYYMMDD format */
 bool		gp_allow_date_field_width_5digits = false;
 
+/* Avoid do a real REFRESH materialized view if possibile. */
+bool		gp_enable_refresh_fast_path = true;
+
 static const struct config_enum_entry gp_log_format_options[] = {
 	{"text", 0},
 	{"csv", 1},
@@ -3126,6 +3129,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 		 false,
 		 NULL, NULL, NULL
 	},
+
+	{
+		{"gp_enable_refresh_fast_path", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("Avoid do a real REFRESH materialized view if possibile."),
+			NULL
+		},
+		&gp_enable_refresh_fast_path,
+		true,
+		NULL, NULL, NULL
+	},
+
 	{
 		{"gp_detect_data_correctness", PGC_USERSET, UNGROUPED,
 		gettext_noop("Detect if the current partitioning of the table or data distribution is correct."),

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -623,6 +623,8 @@ extern bool gp_external_enable_filter_pushdown;
 /* Enable the Global Deadlock Detector */
 extern bool gp_enable_global_deadlock_detector;
 
+extern bool	gp_enable_refresh_fast_path;
+
 extern bool gp_enable_predicate_pushdown;
 extern int  gp_predicate_pushdown_sample_rows;
 

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -196,6 +196,7 @@
 		"gp_enable_predicate_pushdown",
 		"gp_enable_preunique",
 		"gp_enable_query_metrics",
+		"gp_enable_refresh_fast_path",
 		"gp_enable_relsize_collection",
 		"gp_enable_slow_writer_testmode",
 		"gp_enable_sort_distinct",

--- a/src/test/regress/expected/matview.out
+++ b/src/test/regress/expected/matview.out
@@ -746,3 +746,37 @@ NOTICE:  relation "matview_ine_tab" already exists, skipping
 (0 rows)
 
 DROP MATERIALIZED VIEW matview_ine_tab;
+-- test REFRESH fast path
+create materialized view mv_fast as select * from mvtest_t;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'id' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set gp_enable_refresh_fast_path = off;
+select relfilenode into temp mv_fast_relfilenode_0 from pg_class where oid = 'mv_fast'::regclass::oid;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'relfilenode' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+refresh materialized view mv_fast;
+select relfilenode into temp mv_fast_relfilenode_1 from pg_class where oid = 'mv_fast'::regclass::oid;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'relfilenode' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- shoule be 0
+select count(*) from mv_fast_relfilenode_0 natural join mv_fast_relfilenode_1;
+ count 
+-------
+     0
+(1 row)
+
+-- relfilenode should not be changed then.
+set gp_enable_refresh_fast_path = on;
+refresh materialized view mv_fast;
+select relfilenode into temp mv_fast_relfilenode_2 from pg_class where oid = 'mv_fast'::regclass::oid;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'relfilenode' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- shoule be 1
+select count(*) from mv_fast_relfilenode_1 natural join mv_fast_relfilenode_2;
+ count 
+-------
+     1
+(1 row)
+
+reset gp_enable_refresh_fast_path;
+drop materialized view mv_fast;

--- a/src/test/regress/expected/matview_optimizer.out
+++ b/src/test/regress/expected/matview_optimizer.out
@@ -764,3 +764,36 @@ NOTICE:  relation "matview_ine_tab" already exists, skipping
 (0 rows)
 
 DROP MATERIALIZED VIEW matview_ine_tab;
+-- test REFRESH fast path
+create materialized view mv_fast as select * from mvtest_t;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+set gp_enable_refresh_fast_path = off;
+select relfilenode into temp mv_fast_relfilenode_0 from pg_class where oid = 'mv_fast'::regclass::oid;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'relfilenode' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+refresh materialized view mv_fast;
+select relfilenode into temp mv_fast_relfilenode_1 from pg_class where oid = 'mv_fast'::regclass::oid;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'relfilenode' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- shoule be 0
+select count(*) from mv_fast_relfilenode_0 natural join mv_fast_relfilenode_1;
+ count 
+-------
+     0
+(1 row)
+
+-- relfilenode should not be changed then.
+set gp_enable_refresh_fast_path = on;
+refresh materialized view mv_fast;
+select relfilenode into temp mv_fast_relfilenode_2 from pg_class where oid = 'mv_fast'::regclass::oid;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'relfilenode' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- shoule be 1
+select count(*) from mv_fast_relfilenode_1 natural join mv_fast_relfilenode_2;
+ count 
+-------
+     1
+(1 row)
+
+reset gp_enable_refresh_fast_path;
+drop materialized view mv_fast;

--- a/src/test/regress/sql/pg_ext_aux.sql
+++ b/src/test/regress/sql/pg_ext_aux.sql
@@ -40,7 +40,13 @@ select pg_ext_aux.extaux_add1(7);
 -- fail: should not allowed to insert by user
 insert into pg_ext_aux.extaux_t values(1,'hello');
 -- fail: should not allowed to refresh by user
+-- start_ignore
+set gp_enable_refresh_fast_path = off;
+-- end_ignore
 refresh materialized view pg_ext_aux.extaux_mv;
+-- start_ignore
+reset gp_enable_refresh_fast_path;
+-- end_ignore
 
 -- fail: should not allow to be dropped by user
 drop view pg_ext_aux.extaux_v;


### PR DESCRIPTION
We already have the ability to track the data status for some materialized views, aware whether its data is up to date or not.
And we could avoid doing the real REFRESH if the data of view is up to date.

The no-refreshed data should be the logically same as after a real REFRESH when there is no data changed since latest REFRESH command.
In that case we may save a lot (read data from view query, compute and write into view table), ex: a cron task REFRESH view takes a long time and much resource periodically or executed manually by users each time.

New GUC: **gp_enable_refresh_fast_path**

Set this feature default to true, but let users decide if they intend to do a real REFRESH.

### Performance

If the fast path is chosen, we always return immediately and almost do nothing.
And the cost we save depends on the amount of data, the resource we use to compute and the time we read and write back to view table.

```sql
insert into t1 select i from generate_series(1, 100000000) i;
create materialized view mv2 as select * from t1 where a > 1 with no data;
refresh materialized view mv2;
REFRESH MATERIALIZED VIEW
Time: 194061.961 ms (03:14.062)

set gp_enable_refresh_fast_path = on;

refresh materialized view mv2;
REFRESH MATERIALIZED VIEW
Time: 4.617 ms
```


Authored-by: Zhang Mingli avamingli@gmail.com

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
