### PR TITLE
Fix task timezone

### DIFF
--- a/src/backend/task/pg_cron.c
+++ b/src/backend/task/pg_cron.c
@@ -145,6 +145,8 @@ char *task_timezone = "GMT";
 int max_running_tasks = 5;
 char *task_host_addr = "127.0.0.1";
 
+static pg_tz *task_timezone_tz = NULL;
+
 /* flags set by signal handlers */
 static volatile sig_atomic_t got_sigterm = false;
 
@@ -296,6 +298,25 @@ bgw_generate_returned_message(StringInfoData *display_msg, ErrorData edata)
 
 	if (edata.context != NULL)
 		appendStringInfo(display_msg, "\nCONTEXT: %s", edata.context);
+}
+
+void
+assign_task_timezone(const char *newval, void *extra)
+{
+	task_timezone_tz = *((pg_tz **) extra);
+}
+
+const char *show_task_timezone(void)
+{
+	const char *tzn;
+
+	/* Always show the zone's canonical name */
+	tzn = pg_get_timezone_name(task_timezone_tz);
+
+	if (tzn != NULL)
+		return tzn;
+
+	return "unknown";
 }
 
 bool PgCronStartRule(Datum main_arg)

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4733,7 +4733,7 @@ struct config_string ConfigureNamesString_gp[] =
 		},
 		&task_timezone,
 		"GMT",
-		check_timezone, assign_timezone, show_timezone
+		check_timezone, assign_task_timezone, show_task_timezone
 	},
 
 	{

--- a/src/include/task/pg_cron.h
+++ b/src/include/task/pg_cron.h
@@ -33,5 +33,7 @@ extern void CronBackgroundWorker(Datum arg);
 extern pid_t PgCronLauncherPID(void);
 extern Size PgCronLauncherShmemSize(void);
 extern void PgCronLauncherShmemInit(void);
+extern void assign_task_timezone(const char *newval, void *extra);
+extern const char *show_task_timezone(void);
 
 #endif      /* PG_CRON_H */


### PR DESCRIPTION
When set the GUC task_timezone, it will assign and check the new value by hook function assign_timezone and show_timezone. But this two functions are associated with system GUC timezone.

We should add our own hook function for this.

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
