### PR TITLE
cherry-pick signle commit 43a5e58dfa: Clean up logic in CdbTryOpenTable.

### DIFF
--- a/src/backend/access/table/table.c
+++ b/src/backend/access/table/table.c
@@ -184,10 +184,10 @@ table_close(Relation relation, LOCKMODE lockmode)
  *
  * Note1: Postgres will always hold RowExclusiveLock for DMLs
  * Note2: INSERT statement will not call this function.
- * Note3: This function may return NULL (eg. when just before we open the table,
+ * Note3: This function may return NULL (e.g. when just before we open the table,
  *        other transaction drop the table), caller should check it.
  *
- * Cloudberry only upgrade lock level for UPDATE and DELETE statement under some
+ * Greenplum only upgrade lock level for UPDATE and DELETE statement under some
  * condition:
  *   1. always upgrade when gp_enable_global_deadlock_detector is not set
  *   2. when gp_enable_global_deadlock_detector is set:


### PR DESCRIPTION
This commit removes the function UpgradeRelLockAndReuseRelIfNecessary and clean up the implementation of CdbTryOpenTable. Now the logic is:

1. open the relation using some lockmode
2. if need correct lockmode (AO|AOCO with GDD enabled), then close and reopen it using upgraded lockmode
3. if need lockUpgraded information, deduce this using actually mode with request mode.

Also we remove the post-check for AO table not upgrade, because under the new implementation that's impossible to happen and NOTE Greenplum does not support change table's storage kind yet (Even support some day, there will not be any problem).

The other place that uses UpgradeRelLockAndReuseRelIfNecessary is gpdbwrappers.cpp:GPDBLockRelationOid. Before this commit, it passes nullptr to UpgradeRelLockAndReuseRelIfNecessary, thus will open, lock, close the relation, and then lock the relation oid again. This commit implement this by just calling LockRelationOid since there is no need to test lock-upgrade here:
   1. Greenplum only need to upgrade lock level for target relation of DELETE | UPDATE statement
   2. Parse-Analyze stage will always handle root partition correctly and store the lockmode in RTE
   3. ORCA does not support DML on partiton table yet, and in future when implementing this, ORCA should use the lockmode in RTE of root so no need to deduce lock-upgrade
   4. Index does not have lock-upgrade issue.

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
